### PR TITLE
Removed abstract limitation from ProductImporterConfig

### DIFF
--- a/src/Moryx.Products.Management/Components/ProductImporterConfig.cs
+++ b/src/Moryx.Products.Management/Components/ProductImporterConfig.cs
@@ -1,8 +1,10 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.ComponentModel;
 using System.Runtime.Serialization;
 using Moryx.Modules;
+using Moryx.Serialization;
 
 namespace Moryx.Products.Management.Importers
 {
@@ -10,11 +12,13 @@ namespace Moryx.Products.Management.Importers
     /// Config for product importers
     /// </summary>
     [DataContract]
-    public abstract class ProductImporterConfig : IPluginConfig
+    public class ProductImporterConfig : IPluginConfig
     {
         /// <summary>
         /// Name of the component represented by this entry
         /// </summary>
-        public abstract string PluginName { get; }
+        [DataMember, Description("PluginName of the importer")]
+        [PluginNameSelector(typeof(IProductImporter))]
+        public virtual string PluginName { get; set; }
     }
 }


### PR DESCRIPTION
Product importers sometimes need no special configuration. The base class with an adjusted plugin name should be enough.