### PR TITLE
Type argument for message driver

### DIFF
--- a/src/Moryx.AbstractionLayer/Drivers/Message/IMessageCommunication.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Message/IMessageCommunication.cs
@@ -9,12 +9,12 @@ namespace Moryx.AbstractionLayer.Drivers.Message
     /// <summary>
     /// Interface for message based communication
     /// </summary>
-    public interface IMessageCommunication
+    public interface IMessageCommunication<TMessage>
     {
         /// <summary>
         /// Reference to the underlying driver of this communication
         /// </summary>
-        IMessageDriver Driver { get; }
+        IMessageDriver<TMessage> Driver { get; }
 
         /// <summary>
         /// Identifier of this channel
@@ -24,11 +24,11 @@ namespace Moryx.AbstractionLayer.Drivers.Message
         /// <summary>
         /// Send message through the driver
         /// </summary>
-        void Send(object message);
+        void Send(TMessage message);
 
         /// <summary>
         /// Event raised when the driver receives a message
         /// </summary>
-        event EventHandler<object> Received;
+        event EventHandler<TMessage> Received;
     }
 }

--- a/src/Moryx.AbstractionLayer/Drivers/Message/IMessageDriver.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Message/IMessageDriver.cs
@@ -8,11 +8,11 @@ namespace Moryx.AbstractionLayer.Drivers.Message
     /// <summary>
     /// Multi-purpose driver that exchanges messages with the device
     /// </summary>
-    public interface IMessageDriver : IDriver, IMessageCommunication
+    public interface IMessageDriver<TMessage> : IDriver, IMessageCommunication<TMessage>
     {
         /// <summary>
         /// Access a named sub-channel of the driver
         /// </summary>
-        IMessageCommunication this[string identifier] { get; }
+        IMessageCommunication<TMessage> this[string identifier] { get; }
     }
 }

--- a/src/Moryx.AbstractionLayer/Drivers/Plc/IPlcCommunication.cs
+++ b/src/Moryx.AbstractionLayer/Drivers/Plc/IPlcCommunication.cs
@@ -9,7 +9,7 @@ namespace Moryx.AbstractionLayer.Drivers.Plc
     /// <summary>
     /// Interface for communication with the plc
     /// </summary>
-    public interface IPlcCommunication : IMessageCommunication
+    public interface IPlcCommunication : IMessageCommunication<object>
     {
         /// <summary>
         /// Send object to the PLC and await a transmission confirmation


### PR DESCRIPTION
Object was a good and flexible idea, but driver developers should have the ability to decide. Using generics we can now define base classes or interfaces for the message, stick with object or even offer both.

````cs
public class FlexMsgDriver : Driver, IMessageDriver<IFlexMessage>, IMessageDriver<object>
{
}
````

/cc @MarisaGoergen