### PR TITLE
Support GUID in TextColumnMapper

### DIFF
--- a/src/Moryx.Products.Management/Implementation/Storage/TextStrategyConfigurationAttribute.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/TextStrategyConfigurationAttribute.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
+
 namespace Moryx.Products.Management
 {
     public class TextStrategyConfigurationAttribute : PropertyStrategyConfigurationAttribute
@@ -9,7 +11,7 @@ namespace Moryx.Products.Management
         {
             ColumnType = typeof(string);
             DerivedTypes = true;
-            SupportedTypes = new[] {typeof(string), typeof(object)};
+            SupportedTypes = new[] {typeof(string), typeof(object), typeof(Guid)};
         }
     }
 }

--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/TextColumnMapper.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/TextColumnMapper.cs
@@ -25,6 +25,9 @@ namespace Moryx.Products.Management
         protected override IPropertyAccessor<object, string> CreatePropertyAccessor(PropertyInfo objectProp)
         {
             // Convert return value to string
+            if (objectProp.PropertyType == typeof(Guid))
+                return new GuidAccessor(objectProp);
+
             if (objectProp.PropertyType.IsClass && objectProp.PropertyType != typeof(string))
                 return new JsonAccessor(objectProp);
 
@@ -32,7 +35,29 @@ namespace Moryx.Products.Management
         }
 
         /// <summary>
-        /// Accessor decorator to convert objects to enum and back
+        /// Accessor decorator to convert GUID to string and back
+        /// </summary>
+        private class GuidAccessor : ConversionAccessor<string, Guid>
+        {
+            public GuidAccessor(PropertyInfo property) : base(property)
+            {
+            }
+
+            public override string ReadProperty(object instance)
+            {
+                var value = Target.ReadProperty(instance);
+                return value.ToString();
+            }
+
+            public override void WriteProperty(object instance, string value)
+            {
+                var guid = Guid.Parse(value);
+                Target.WriteProperty(instance, guid);
+            }
+        }
+
+        /// <summary>
+        /// Accessor decorator to convert objects to JSON and back
         /// </summary>
         private class JsonAccessor : ConversionAccessor<string, object>
         {

--- a/src/Moryx.Products.Samples/ProductInstances/WatchfaceInstance.cs
+++ b/src/Moryx.Products.Samples/ProductInstances/WatchfaceInstance.cs
@@ -1,11 +1,18 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using Moryx.AbstractionLayer.Products;
 
 namespace Moryx.Products.Samples
 {
     public class WatchfaceInstance : ProductInstance<WatchfaceType>
     {
+        public Guid Identifier { get; set; }
+
+        public WatchfaceInstance()
+        {
+            Identifier = Guid.NewGuid();
+        }
     }
 }

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
@@ -129,7 +129,15 @@ namespace Moryx.Products.IntegrationTests
                     new GenericInstanceConfiguration
                     {
                         TargetType = nameof(WatchfaceInstance),
-                        PropertyConfigs = new List<PropertyMapperConfig>(),
+                        PropertyConfigs = new List<PropertyMapperConfig>
+                        {
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchfaceInstance.Identifier),
+                                Column = nameof(IGenericColumns.Text1),
+                                PluginName = nameof(TextColumnMapper)
+                            }
+                        },
                         JsonColumn = nameof(IGenericColumns.Text8)
                     },
                     new ProductInstanceConfiguration()
@@ -660,6 +668,7 @@ namespace Moryx.Products.IntegrationTests
             Assert.AreEqual(instance.DeliveryDate, watchCopy.DeliveryDate);
             Assert.AreEqual(instance.TimeSet, watchCopy.TimeSet);
             Assert.NotNull(instance.Watchface);
+            Assert.AreEqual(instance.Watchface.Identifier, watchCopy.Watchface.Identifier, "Guid does not match");
             Assert.NotNull(instance.Needles);
             Assert.AreEqual(3, instance.Needles.Count);
         }


### PR DESCRIPTION
GUIDs are not supported by the text column mapper, so instead of writing them to JSON, a text column can be used.

/cc @MarisaGoergen 