### PR TITLE
Extend instance loading API in ProductManagement

### DIFF
--- a/src/Moryx.AbstractionLayer/Identity/NumberIdentity.cs
+++ b/src/Moryx.AbstractionLayer/Identity/NumberIdentity.cs
@@ -35,7 +35,9 @@ namespace Moryx.AbstractionLayer.Identity
         [DataMember]
         public string Identifier { get; protected set; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Field for enum values to distinguish between different values
+        /// </summary>
         [DataMember]
         public int NumberType { get; protected set; }
 

--- a/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
+++ b/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
+using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Workflows;
 
@@ -87,6 +89,18 @@ namespace Moryx.AbstractionLayer.Products
         ProductInstance GetInstance(long id);
 
         /// <summary>
+        /// Get a product instance by identity
+        /// </summary>
+        TInstance GetInstance<TInstance>(IIdentity identity)
+            where TInstance : ProductInstance;
+
+        /// <summary>
+        /// Get product instance by expression
+        /// </summary>
+        TInstance GetInstance<TInstance>(Expression<Predicate<TInstance>> selector)
+            where TInstance : ProductInstance;
+
+        /// <summary>
         /// Updates the database from the product instance
         /// </summary>
         void SaveInstance(ProductInstance productInstance);
@@ -97,13 +111,9 @@ namespace Moryx.AbstractionLayer.Products
         void SaveInstances(ProductInstance[] productInstances);
 
         /// <summary>
-        /// Gets a list of product instances by a given state
+        /// Get all instances that match a certain 
         /// </summary>
-        IEnumerable<ProductInstance> GetInstances(ProductInstanceState state);
-
-        /// <summary>
-        /// Load product instances using combined bit flags
-        /// </summary>
-        IEnumerable<ProductInstance> GetInstances(int combinedState);
+        IEnumerable<TInstance> GetInstances<TInstance>(Expression<Predicate<TInstance>> selector)
+            where TInstance : ProductInstance;
     }
 }

--- a/src/Moryx.Products.Management/Components/IProductManager.cs
+++ b/src/Moryx.Products.Management/Components/IProductManager.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using Moryx.AbstractionLayer;
+using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Products;
 using Moryx.Modules;
 using Moryx.Products.Management.Importers;
@@ -83,18 +85,26 @@ namespace Moryx.Products.Management
         ProductInstance GetInstance(long id);
 
         /// <summary>
-        /// Gets a list of instances by a given state
+        /// Get a product instance by identity
         /// </summary>
-        IEnumerable<ProductInstance> GetInstances(ProductInstanceState state);
+        TInstance GetInstance<TInstance>(IIdentity identity)
+            where TInstance : ProductInstance;
 
         /// <summary>
-        /// Load instances using combined bit flags
+        /// Get product instance by expression
         /// </summary>
-        IEnumerable<ProductInstance> GetInstances(int state);
+        TInstance GetInstance<TInstance>(Expression<Predicate<TInstance>> selector)
+            where TInstance : ProductInstance;
 
         /// <summary>
         /// Updates the database from the instance
         /// </summary>
         void SaveInstances(params ProductInstance[] productInstances);
+
+        /// <summary>
+        /// Get all instances that match a certain 
+        /// </summary>
+        IEnumerable<TInstance> GetInstances<TInstance>(Expression<Predicate<TInstance>> selector)
+            where TInstance : ProductInstance;
     }
 }

--- a/src/Moryx.Products.Management/Components/IProductStorage.cs
+++ b/src/Moryx.Products.Management/Components/IProductStorage.cs
@@ -1,7 +1,10 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
+using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Model.Repositories;
@@ -31,11 +34,6 @@ namespace Moryx.Products.Management
         IProductType LoadType(ProductIdentity identity);
 
         /// <summary>
-        /// Transform a given a type entity
-        /// </summary>
-        IProductType TransformType(IUnitOfWork context, ProductTypeEntity typeEntity, bool full);
-
-        /// <summary>
         /// Save a type to the storage
         /// </summary>
         long SaveType(IProductType modifiedInstance);
@@ -48,9 +46,22 @@ namespace Moryx.Products.Management
         ProductInstance LoadInstance(long id);
 
         /// <summary>
+        /// Get a product instance by identity
+        /// </summary>
+        TInstance LoadInstance<TInstance>(IIdentity identity)
+            where TInstance : ProductInstance;
+
+        /// <summary>
+        /// Get product instance by expression
+        /// </summary>
+        TInstance LoadInstance<TInstance>(Expression<Predicate<TInstance>> selector)
+            where TInstance : ProductInstance;
+
+        /// <summary>
         /// Load instances using combined bit flags
         /// </summary>
-        IEnumerable<ProductInstance> LoadInstances(int state);
+        IEnumerable<TInstance> LoadInstances<TInstance>(Expression<Predicate<TInstance>> selector)
+            where TInstance : ProductInstance;
 
         /// <summary>
         /// Updates the database from the instance

--- a/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
+++ b/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Moryx.AbstractionLayer;
+using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Runtime.Modules;
@@ -169,6 +171,18 @@ namespace Moryx.Products.Management
             return ProductManager.GetInstance(id);
         }
 
+        public TInstance GetInstance<TInstance>(IIdentity identity) where TInstance : ProductInstance
+        {
+            ValidateHealthState();
+            return ProductManager.GetInstance<TInstance>(identity);
+        }
+
+        public TInstance GetInstance<TInstance>(Expression<Predicate<TInstance>> selector) where TInstance : ProductInstance
+        {
+            ValidateHealthState();
+            return ProductManager.GetInstance<TInstance>(selector);
+        }
+
         public void SaveInstance(ProductInstance productInstance)
         {
             ValidateHealthState();
@@ -181,16 +195,10 @@ namespace Moryx.Products.Management
             ProductManager.SaveInstances(productInstance);
         }
 
-        public IEnumerable<ProductInstance> GetInstances(ProductInstanceState state)
+        public IEnumerable<TInstance> GetInstances<TInstance>(Expression<Predicate<TInstance>> selector) where TInstance : ProductInstance
         {
             ValidateHealthState();
-            return ProductManager.GetInstances(state);
-        }
-
-        public IEnumerable<ProductInstance> GetInstances(int state)
-        {
-            ValidateHealthState();
-            return ProductManager.GetInstances(state);
+            return ProductManager.GetInstances<TInstance>(selector);
         }
 
         private static void ValidateRecipe(IProductRecipe recipe)

--- a/src/Moryx.Products.Management/Implementation/ProductManager.cs
+++ b/src/Moryx.Products.Management/Implementation/ProductManager.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Moryx.AbstractionLayer;
+using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Container;
@@ -182,14 +184,19 @@ namespace Moryx.Products.Management
             return Storage.LoadInstance(id);
         }
 
-        public IEnumerable<ProductInstance> GetInstances(ProductInstanceState state)
+        public TInstance GetInstance<TInstance>(IIdentity identity) where TInstance : ProductInstance
         {
-            return Storage.LoadInstances((int)state);
+            return Storage.LoadInstance<TInstance>(identity);
+        }
+        
+        public TInstance GetInstance<TInstance>(Expression<Predicate<TInstance>> selector) where TInstance : ProductInstance
+        {
+            return Storage.LoadInstance(selector);
         }
 
-        public IEnumerable<ProductInstance> GetInstances(int state)
+        public IEnumerable<TInstance> GetInstances<TInstance>(Expression<Predicate<TInstance>> selector) where TInstance : ProductInstance
         {
-            return Storage.LoadInstances(state);
+            return Storage.LoadInstances(selector);
         }
 
         private void RaiseProductChanged(IProductType productType)


### PR DESCRIPTION
We can currently only load instances by Id and state. This extends support with `IIdentity` and `Expressions`