### PR TITLE
Add ResourceRemoved event on Facade

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/IResourceManagement.cs
+++ b/src/Moryx.AbstractionLayer/Resources/IResourceManagement.cs
@@ -65,7 +65,12 @@ namespace Moryx.AbstractionLayer.Resources
         /// <summary>
         /// Event raised when a resource was added at runtime
         /// </summary>
-        event EventHandler<IPublicResource> ResourceAdded; 
+        event EventHandler<IPublicResource> ResourceAdded;
+
+        /// <summary>
+        /// Event raised when a resource was removed at runtime
+        /// </summary>
+        event EventHandler<IPublicResource> ResourceRemoved;
 
         /// <summary>
         /// Raised when the capabilities have changed.

--- a/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
@@ -29,6 +29,7 @@ namespace Moryx.Resources.Management
         {
             Manager.ResourceAdded += OnResourceAdded;
             Manager.CapabilitiesChanged += OnCapabilitiesChanged;
+            Manager.ResourceRemoved += OnResourceRemoved;
         }
 
         /// <seealso cref="IFacadeControl"/>
@@ -36,6 +37,7 @@ namespace Moryx.Resources.Management
         {
             Manager.ResourceAdded -= OnResourceAdded;
             Manager.CapabilitiesChanged -= OnCapabilitiesChanged;
+            Manager.ResourceRemoved -= OnResourceRemoved;
         }
 
 
@@ -47,6 +49,11 @@ namespace Moryx.Resources.Management
         private void OnResourceAdded(object sender, IPublicResource publicResource)
         {
             ResourceAdded?.Invoke(this, publicResource.Proxify(TypeController));
+        }
+
+        private void OnResourceRemoved(object sender, IPublicResource publicResource)
+        {
+            ResourceRemoved?.Invoke(this, publicResource.Proxify(TypeController));
         }
 
         public TResource GetResource<TResource>() where TResource : class, IPublicResource
@@ -105,6 +112,9 @@ namespace Moryx.Resources.Management
 
         /// <inheritdoc />
         public event EventHandler<IPublicResource> ResourceAdded;
+
+        /// <inheritdoc />
+        public event EventHandler<IPublicResource> ResourceRemoved;
 
         /// <inheritdoc />
         public event EventHandler<ICapabilities> CapabilitiesChanged;

--- a/src/Moryx.Resources.Management/Resources/IResourceManager.cs
+++ b/src/Moryx.Resources.Management/Resources/IResourceManager.cs
@@ -24,6 +24,11 @@ namespace Moryx.AbstractionLayer.Resources
         event EventHandler<IPublicResource> ResourceAdded;
 
         /// <summary>
+        /// Event raised when a resource was removed at runtime
+        /// </summary>
+        event EventHandler<IPublicResource> ResourceRemoved;
+
+        /// <summary>
         /// Raised when the capabilities have changed.
         /// </summary>
         event EventHandler<ICapabilities> CapabilitiesChanged;

--- a/src/Moryx.Resources.Management/Resources/ResourceManager.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceManager.cs
@@ -377,6 +377,11 @@ namespace Moryx.Resources.Management
             var instance = (Resource)resource;
             ((IPlugin)resource).Stop();
 
+            // Notify listeners about the removal of the resource
+            var publicResource = instance as IPublicResource;
+            if (publicResource != null)
+                RaiseResourceRemoved(publicResource);
+
             // Load entity and relations to disconnect resource and remove from database
             using (var uow = UowFactory.Create())
             {
@@ -422,6 +427,12 @@ namespace Moryx.Resources.Management
             ResourceAdded?.Invoke(this, newResource);
         }
         public event EventHandler<IPublicResource> ResourceAdded;
+
+        private void RaiseResourceRemoved(IPublicResource newResource)
+        {
+            ResourceRemoved?.Invoke(this, newResource);
+        }
+        public event EventHandler<IPublicResource> ResourceRemoved;
 
         ///
         public event EventHandler<ICapabilities> CapabilitiesChanged;


### PR DESCRIPTION
Pull request to tackle issue #36 

Added ResourceRemoved events whereever a corresponding ResourceAdded event existed and invoke the event when a resource is destroyed.
Notification via the event is done before the resource is removed from the ResourceGraph to allow others to navigate through the graph in reaction. 

