### PR TITLE
Added missing WorkplanExtensions for activities with interface parameters

### DIFF
--- a/src/Moryx.AbstractionLayer/Workplan/WorkplanExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Workplan/WorkplanExtensions.cs
@@ -13,8 +13,6 @@ namespace Moryx.AbstractionLayer
         /// <summary>
         /// Adds a step to the workplan
         /// </summary>
-        /// <typeparam name="TActivity"></typeparam>
-        /// <typeparam name="TParam"></typeparam>
         /// <param name="workplan">The workplan.</param>
         /// <param name="task">The task to add.</param>
         /// <param name="parameter">The parameter for the task.</param>
@@ -22,13 +20,13 @@ namespace Moryx.AbstractionLayer
         /// <param name="outputs">The outputs of the steps.</param>
         /// <returns></returns>
         public static TaskStep<TActivity, TParam> AddStep<TActivity,TParam>(this Workplan workplan, TaskStep<TActivity,TParam> task, TParam parameter, IConnector input, params IConnector[] outputs)
-        where TActivity : IActivity<TParam>, new()
-        where TParam : IParameters, new()
+            where TActivity : IActivity<TParam>, new()
+            where TParam : IParameters, new()
         {
             task.Parameters = parameter;
             task.Inputs[0] = input;
 
-            for (int i = 0; i < outputs.Length; i++)
+            for (var i = 0; i < outputs.Length; i++)
             {
                 task.Outputs[i] = outputs[i];
             }
@@ -44,8 +42,36 @@ namespace Moryx.AbstractionLayer
         /// <summary>
         /// Adds a step to the workplan
         /// </summary>
-        /// <typeparam name="TActivity"></typeparam>
-        /// <typeparam name="TParam"></typeparam>
+        /// <param name="workplan">The workplan.</param>
+        /// <param name="task">The task to add.</param>
+        /// <param name="parameter">The parameter for the task.</param>
+        /// <param name="input">The input for the step</param>
+        /// <param name="outputs">The outputs of the steps.</param>
+        /// <returns></returns>
+        public static TaskStep<TActivity, TProcParam, TParam> AddStep<TActivity, TProcParam, TParam>(this Workplan workplan, TaskStep<TActivity, TProcParam, TParam> task, TParam parameter, IConnector input, params IConnector[] outputs)
+            where TActivity : IActivity<TProcParam>, new()
+            where TProcParam : IParameters
+            where TParam : TProcParam, new()
+        {
+            task.Parameters = parameter;
+            task.Inputs[0] = input;
+
+            for (var i = 0; i < outputs.Length; i++)
+            {
+                task.Outputs[i] = outputs[i];
+            }
+
+            if (task.Outputs.Length != outputs.Length)
+                throw new ArgumentException($"Wrong number of outputs for the task {task.Name}");
+
+            workplan.Add(task);
+
+            return task;
+        }
+
+        /// <summary>
+        /// Adds a step to the workplan
+        /// </summary>
         /// <param name="workplan">The workplan.</param>
         /// <param name="task">The task to add.</param>
         /// <param name="parameter">The parameter for the task.</param>
@@ -53,8 +79,8 @@ namespace Moryx.AbstractionLayer
         /// <param name="outputs">The outputs of the steps.</param>
         /// <returns></returns>
         public static TaskStep<TActivity, TParam> AddStep<TActivity, TParam>(this Workplan workplan, TaskStep<TActivity, TParam> task, TParam parameter, IConnector[] input, params IConnector[] outputs)
-        where TActivity : Activity<TParam>, new()
-        where TParam : IParameters, new()
+            where TActivity : Activity<TParam>, new()
+            where TParam : IParameters, new()
         {
             task.Parameters = parameter;
             for (var i = 0; i < input.Length; i++)
@@ -71,12 +97,43 @@ namespace Moryx.AbstractionLayer
 
             return task;
         }
+
+        /// <summary>
+        /// Adds a step to the workplan
+        /// </summary>
+        /// <param name="workplan">The workplan.</param>
+        /// <param name="task">The task to add.</param>
+        /// <param name="parameter">The parameter for the task.</param>
+        /// <param name="input">The input for the step</param>
+        /// <param name="outputs">The outputs of the steps.</param>
+        /// <returns></returns>
+        public static TaskStep<TActivity, TProcParam, TParam> AddStep<TActivity, TProcParam, TParam>(this Workplan workplan, TaskStep<TActivity, TProcParam, TParam> task, TParam parameter, IConnector[] input, params IConnector[] outputs)
+            where TActivity : Activity<TProcParam>, new()
+            where TProcParam : IParameters
+            where TParam : TProcParam, new()
+        {
+            task.Parameters = parameter;
+            for (var i = 0; i < input.Length; i++)
+            {
+                task.Inputs[i] = input[i];
+            }
+
+            for (var i = 0; i < outputs.Length; i++)
+            {
+                task.Outputs[i] = outputs[i];
+            }
+
+            workplan.Add(task);
+
+            return task;
+        }
+
         /// <summary>
         /// Adds a connector to the workplan.
         /// </summary>
         /// <param name="workplan">The workplan.</param>
         /// <param name="name">The name of the connector.</param>
-        /// <param name="classification">The classification of the conncetor.</param>
+        /// <param name="classification">The classification of the connector.</param>
         /// <returns></returns>
         public static IConnector AddConnector(this Workplan workplan, string name, NodeClassification classification)
         {


### PR DESCRIPTION
Added workplan extensions for Tasks and Activities with interface parameters fixed in #62 .

@Toxantron do you have an idea how to reduce copy and paste here?

This should be merged if we plan to release AL 5.2