### PR TITLE
Fix typos and make improvements in docs

### DIFF
--- a/docs/articles/AbstractionLayer.md
+++ b/docs/articles/AbstractionLayer.md
@@ -40,8 +40,7 @@ A [Process](Processing/Processes.md) consists of a series of activities.
 
 ## Products
 
-A [ProductType](xref:Moryx.AbstractionLayer.Products.IProductType) or better a *product description* is used by a [ProductRecipe](xref:Moryx.AbstractionLayer.Recipes.
-ProductRecipe) to provide a basic structure to produce a [ProductInstance](xref:Moryx.AbstractionLayer.Products.ProductInstance) 
+A [ProductType](xref:Moryx.AbstractionLayer.Products.IProductType) or better a *product description* is used by a [ProductRecipe](xref:Moryx.AbstractionLayer.Recipes.ProductRecipe) to provide a basic structure to produce a [ProductInstance](xref:Moryx.AbstractionLayer.Products.ProductInstance) 
 
 ## Recipes
 

--- a/docs/articles/Processing/Activities.md
+++ b/docs/articles/Processing/Activities.md
@@ -53,7 +53,7 @@ This property defines if a process is necessary to handle this activity.
 
 ### Create Result
 
-There are two methods to create a result for the activity. One to define a failed activity and one to define a result depending on a given number which encodes a result from the result enum of the activity. A more detailed discussion of activity results can be found [later on in this article](Activities.md#activity-results).   
+There are two methods to create a result for the activity. One to define a failed activity and one to define a result depending on a given number which encodes a result from the result enum of the activity. A more detailed discussion of activity results can be found [later in this article](Activities.md#activity-results).   
 
 ## Activity Parameters
 

--- a/docs/articles/Processing/Capabilities.md
+++ b/docs/articles/Processing/Capabilities.md
@@ -3,7 +3,7 @@ uid: Capabilities
 ---
 # Capabilities
 
-[Capabilities](xref:Moryx.AbstractionLayer.Capabilities.ICapabilities) are based on the idea of [set theory](https://en.wikipedia.org/wiki/Set_theory). Each class with its attributes and functions describes a set. Within MORYX modules can use required capabilities to describe a set and fetch aöö resources from the `ResourceManagement` that fullfil the membership function are part of that set. [Resources](../Resources/Overview.md) can export their capabilities to be matched against the required capabilities. Every [Activity](Activities.md) defines which capabilities it needs and the provided information will be used to find a matching Resource to handle the activity. It is also possible that a resource has multiple capabilities and is able to handle various activities.
+[Capabilities](xref:Moryx.AbstractionLayer.Capabilities.ICapabilities) are based on the idea of [set theory](https://en.wikipedia.org/wiki/Set_theory). Each class with its attributes and functions describes a set. Within MORYX, modules can use required capabilities to describe a set and fetch resources from the `ResourceManagement` that fullfil the membership function, which are part of that set. [Resources](../Resources/Overview.md) can export their capabilities to be matched against the required capabilities. Every [Activity](Activities.md) defines which capabilities it needs and the provided information will be used to find a matching Resource to handle the activity. It is also possible that a resource has multiple capabilities and is able to handle various activities.
 
 ![Capabilities](images/capabilities.svg)
 
@@ -38,7 +38,7 @@ public class MyCapabilities : ConcreteCapabilities
 }
 ````
 
-In any case you can extend your capabilities with more properties to give the resource are more meaningfull self description. Let's take the ScrewingCapabilities as an example. Maybe there is more than one station which has ScrewingCapabilities but each can handle a different screw head. Our Capability implementation could then look like:
+In any case you can extend your capabilities with more properties to give the resource are more meaningful self description. Let's take the ScrewingCapabilities as an example. Maybe there is more than one station which has ScrewingCapabilities but each can handle a different screw head. Our Capability implementation could then look like:
 
 ```` cs
 public enum ScrewHead

--- a/docs/articles/Processing/Constraints.md
+++ b/docs/articles/Processing/Constraints.md
@@ -5,7 +5,7 @@ uid: Constraints
 
 [Constraints](xref:Moryx.AbstractionLayer.IConstraint) as well as [Capabilities](xref:Moryx.AbstractionLayer.Capabilities.ICapabilities) are used to filter the possible matches of [Resources](xref:Moryx.Resources.IResource) and [Activities](xref:Moryx.AbstractionLayer.IActivity).
 In Contrast to capabilities which are sets of provided and required abilities, constraints are boolean conditions which arise from the system's context.
-To check if the context's constraints are met the [Check()](xref:Moryx.AbstractionLayer.IConstraint.Check) method of the constraint is called.
+To check if the context's constraints are met the [Check()](xref:Moryx.AbstractionLayer.IConstraint#Moryx_AbstractionLayer_IConstraint_Check_Moryx_AbstractionLayer_IConstraintContext_) method of the constraint is called.
 The [IConstraintContext](xref:Moryx.AbstractionLayer.IConstraintContext) contains all the information which is needed to perform this check.
 
 ## ExpressionConstraint

--- a/docs/articles/Processing/Workplans.md
+++ b/docs/articles/Processing/Workplans.md
@@ -3,22 +3,24 @@ uid: Workplans
 ---
 # Workplans
 
-A [Workplan](xref:Moryx.Workflows.IWorkplan) is the definition of the production flow of a product how it should be produced at a machine and which steps must be executed and in which order. Therefore it contains a list of steps and connectors. The diagram is a model on its own. The workflow control model does not contain any information of a diagram.
+A `Workplan` is the definition of the production flow of a product how it should be produced at a machine and which steps must be executed and in which order. Therefore it contains a list of steps and connectors. The diagram is a model on its own. The workflow control model does not contain any information of a diagram.
+
+See the documentation in the [MORYX-Platform GitHub Repository](https://github.com/PHOENIXCONTACT/MORYX-Platform) to get more detailed information about Workplan, Step and Connector interface.
 
 ## Workplan Step
 
-A [workplan step](xref:Moryx.Workflows.IWorkplanStep) is basically the Task which must be implemented in an application to define the needed step in the production. The task will create the corresponding activity during the processing of the workplan.
+A `workplan step` is basically the Task which must be implemented in an application to define the needed step in the production. The task will create the corresponding activity during the processing of the workplan.
 
 ## Connector
 
-A [connector](xref:Moryx.Workflows.IConnector) is the connection between two steps to define the possible paths from the start of the workplan over the used tasks until an endpoint is reached.
+A `connector` is the connection between two steps to define the possible paths from the start of the workplan over the used tasks until an endpoint is reached.
 
 ## Meta-Model
 
 - An activity is the base type for all kinds of activities. An Activity is executed by a resource. An activity references the process it belongs to.
 - An activity can have one or more aspects.
 - A production activity represents the execution of a production step.
-- An production activity can have access to the data of a product.
+- A production activity can have access to the data of a product.
 - A process step can have a material which is available for production. If no material is given, the production activity provides some material, e.g. the worker puts some material on a WPC.
 - A process is a series of activities.
 - A production process contains a reference to the data of the workpiece the process is physically working on.
@@ -56,12 +58,12 @@ A work plan has a version identifier. There is some kind of release management n
 
 To reduce waist there must be a possibility to change the work plan version while the process is running. To change should be allowed only if the finished and the current steps are equal to the new definition. It should be quite easy to check the tracing data whether the new definition would have led to the same tracing result. It should be forbidden to change the version if the tracing data does not fit to the new one.
 
-For each group of splits and joins leading to parallel threads there must be a bounding box with exactly one entry and one exit. The only exception of this rule is a global abort, if the process shall be terminated in case of an error. Its difficult (or even impossible) to validate termination if loops are allowed, because the termination of the loop cannot be validated at all.
+For each group of splits and joins leading to parallel threads there must be a bounding box with exactly one entry and one exit. The only exception of this rule is a global abort, if the process shall be terminated in case of an error. It is difficult (or even impossible) to validate termination if loops are allowed, because the termination of the loop cannot be validated at all.
 
 
 ## Create a Workplan
 
-The most comfortable way is to use the workplan editor to draw the workplan with the created task. But it is also possible to create a workplan programmatically to use it for example during the product import. A self created workplan could be looks like that:
+The most comfortable way is to use the workplan editor to draw the workplan with the created task. But it is also possible to create a workplan programmatically to use it for example during the product import. A self-created workplan could look like this:
 
 ```` cs
 // Prepare workplan
@@ -98,4 +100,4 @@ workplan.Validate();
 RecipeStorage.SaveWorkplan(openContext, workplan);
 ````
 
-The method `AddStep` of the workplan takes a list of connectors which must fit the result enum of the corresponding activity of the used task. If it does not fit then the validation will throw an exception. In the shown example has the MountTask only two outputs where the first one is the `Mounted` connector and the last goes directly to the `Failed` output. The other activities have three possible result where two of them goes directly to the failed output. The `UnmountTask` is the last task and its first output which is the success path goes to the `End` output to close the good path of this workplan.
+The method `AddStep` of the workplan takes a list of connectors which must fit the result enum of the corresponding activity of the used task. If it does not fit then the validation will throw an exception. In the shown example has the MountTask only two outputs where the first one is the `Mounted` connector and the last goes directly to the `Failed` output. The other activities have three possible results where two of them go directly to the failed output. The `UnmountTask` is the last task and its first output, which is the success path, goes to the `End` output to close the good path of this workplan.

--- a/docs/articles/Products/Concept.md
+++ b/docs/articles/Products/Concept.md
@@ -20,7 +20,7 @@ For more information regarding the definition of a product including a detailed 
 
 A recipe is used to provide a [Workplan](../Processing/Workplans.md) for a [Process](../Processing/Processes.md) in which a product is processed. It can also provides additional parameters related to the `workplan`. All recipes are derived from [Recipe](xref:Moryx.AbstractionLayer.Recipe).
 
-The Abstraction Layer provides the [IProductRecipe](xref:Moryx.AbstractionLayer.IProductRecipe) and [IWorkplanRecipe](xref:Moryx.AbstractionLayer.IWorkplanRecipe) which can be used separatly or combined. 
+The Abstraction Layer provides the [IProductRecipe](xref:Moryx.AbstractionLayer.Recipes.IProductRecipe) and [IWorkplanRecipe](xref:Moryx.AbstractionLayer.Recipes.IWorkplanRecipe) which can be used separatly or combined. 
 In a production environment, for example, we have the `process` with the belonging `product` and the corresponding `workplan`. 
 The parameters regarding the products production (e.g. the material needed, technical parameters for automatic testing, etc) are provided with the `product recipe` while the `workplan` and parameters to configure it come with the `workplan recipe`.
 

--- a/docs/articles/Products/ProductDefinition.md
+++ b/docs/articles/Products/ProductDefinition.md
@@ -12,11 +12,11 @@ The level 1 product group definition is done by creating a class used to represe
 
 ## Product Parts
 
-In most cases it makes sense to model complex products as compositions of parts instead of one huge product. Those references to products are not represented as simple properties but with an explicit link object. This structure of [IProductPartLink](xref:Moryx.AbstractionLayer.IProductPartLink) was created because in many cases the reference carriers attributes of its own that are neither part of the product nor its part but rather define the relationship between them. For example a watch could have two or three needles that each indicate a respective part of the time (hours, minutes, seconds, stopwatch). The role of each needle could be a part of the needle product definition, but then it would not be possible to use a certain needle for seconds on one watch and for a stopwatch on another one. Furthermore if you think of the watch needle as an isolated product, its attributes rather include size, color and shape - but not its role in a watch. To define custom attributes for relationships between products a class derived from [ProductPartLink<TProduct>](xref:Moryx.AbstractionLayer.ProductPartLink) must be created and used within the product.
+In most cases it makes sense to model complex products as compositions of parts instead of one huge product. Those references to products are not represented as simple properties but with an explicit link object. This structure of [IProductPartLink](xref:Moryx.AbstractionLayer.Products.IProductPartLink) was created because in many cases the reference carriers attributes of its own that are neither part of the product nor its part but rather define the relationship between them. For example a watch could have two or three needles that each indicate a respective part of the time (hours, minutes, seconds, stopwatch). The role of each needle could be a part of the needle product definition, but then it would not be possible to use a certain needle for seconds on one watch and for a stopwatch on another one. Furthermore if you think of the watch needle as an isolated product, its attributes rather include size, color and shape - but not its role in a watch. To define custom attributes for relationships between products a class derived from [ProductPartLink<TProduct>](xref:Moryx.AbstractionLayer.Products.ProductPartLink) must be created and used within the product.
 
 ## Create Instance
 
-Each product must provide a method to create typed instances of itself. Those instances are represented by classes derived from [ProductInstance](xref:Moryx.AbstractionLayer.ProductInstance) as described below. To create instances of complex products a recursive approach is used. Each product only creates an instance of itself and fills its parts by creating instances of its parts. Unlike products, instances do not define link objects for references but the link attributes become part of the instance attributes. This makes sense if you think about our previous example of watch needles. While the needle product may be used in different roles in different watches the one concrete needle used to assemble a single watch most definitly has one and only one role.
+Each product must provide a method to create typed instances of itself. Those instances are represented by classes derived from [ProductInstance](xref:Moryx.AbstractionLayer.Products.ProductInstance) as described below. To create instances of complex products a recursive approach is used. Each product only creates an instance of itself and fills its parts by creating instances of its parts. Unlike products, instances do not define link objects for references but the link attributes become part of the instance attributes. This makes sense if you think about our previous example of watch needles. While the needle product may be used in different roles in different watches the one concrete needle used to assemble a single watch most definitly has one and only one role.
 
 ### Sample code
 
@@ -35,7 +35,7 @@ public class WatchProduct : ProductType
     public ProductPartLink<WatchfaceProduct> Watchface { get; set; }
     public List<NeedlePartLink> Needles { get; set; }
 
-    protected override ProdectInstance Instantiate()
+    protected override ProductInstance Instantiate()
     {
         return new WatchInstance
         {
@@ -80,7 +80,7 @@ public class NeedlePartLink : ProductPartLink<NeedleProduct>
 
 ## Product Level 2
 
-Level 2 of the product definition defines concrete product variants within a group. Speaking in code those are instances of the classes. These variants differ in their values for the attributes defined in the first step and the products referenced as parts. For example different watches have different prices, analog or digital watchfaces and two or three  needles. The product here is only an example and a real watch product would probably be a lot more complex. If level 1 is achieved by writing a class definition, then level 2 is achieved by creating instances of this class. Each instance also carriers its product identity that can be any implementation of [IIdentity](xref:Moryx.AbstractionLayer.Identity.IIdentity). We only use [ProductIdentity](xref:Moryx.AbstractionLayer.ProductIdentity) that contains an identifier and a revision.
+Level 2 of the product definition defines concrete product variants within a group. Speaking in code those are instances of the classes. These variants differ in their values for the attributes defined in the first step and the products referenced as parts. For example different watches have different prices, analog or digital watchfaces and two or three  needles. The product here is only an example and a real watch product would probably be a lot more complex. If level 1 is achieved by writing a class definition, then level 2 is achieved by creating instances of this class. Each instance also carriers its product identity that can be any implementation of [IIdentity](xref:Moryx.AbstractionLayer.Identity.IIdentity). We only use [ProductIdentity](xref:Moryx.AbstractionLayer.Products.ProductIdentity) that contains an identifier and a revision.
 
 ### Sample Code
 
@@ -135,7 +135,7 @@ Instances of products are defined as classes and in most cases there is a 1:1 re
 
 * Analog and digital watches are represented by two product classes `AnalogWatchProduct` and `DigitalWatchProduct` to avoid having an empty collection of needles in digital watches, but both create `Watch` instances * The `WatchfaceProduct` creates instances of `AnalogWatch` or `DigitalWatch` depending on the value of `IsDigital` of the watch face.
 
-All instance class definitions must be derived from [ProductInstance](xref:Moryx.AbstractionLayer.ProductInstance) and only define instance properties valid for the single physical instance. The base class already defines instance properties like state, production date or identity (serial number). Articles also define references to instances of its parts.
+All instance class definitions must be derived from [ProductInstance](xref:Moryx.AbstractionLayer.Products.ProductInstance) and only define instance properties valid for the single physical instance. The base class already defines instance properties like state, production date or identity (serial number). Articles also define references to instances of its parts.
 
 ### Sample Code
 

--- a/docs/articles/Products/ProductImport.md
+++ b/docs/articles/Products/ProductImport.md
@@ -10,7 +10,7 @@ Product imports of a machine are created by implementing the [IProductImporter](
 The base class requires three methods:
 
 * **GenerateParameters:** This override is optional in case your parameters object requires more initialization than a simple constructor invocation. Otherwise you can leave the default behavior.
-* **UpdateParameters:** Some parameters where entered by the user and the importer can now update, add or modify other parameters. This provides an interactive workflow between the client and importer plugin. For example an importer could prefill the revision field after a material number was entered.
+* **UpdateParameters:** Some parameters were entered by the user and the importer can now update, add or modify other parameters. This provides an interactive workflow between the client and importer plugin. For example an importer could prefill the revision field after a material number was entered.
 * **Import:** Parse the parameters from the client and construct an `IProduct` instance. **DO NOT** write this to the database, but return the unsaved object instead.
 
 It is important that the new created importer is configured in the **Maintenance -> ProductManager -> Importers**.

--- a/docs/articles/Products/ProductManagement.md
+++ b/docs/articles/Products/ProductManagement.md
@@ -11,7 +11,7 @@ The [ProductManagement](xref:Moryx.Products.Management) is a server module provi
 
 ProductManager's public API is provided by the following facades:
 
-* [IProductManagement](xref:Moryx.Products.IProductManagement) 
+* [IProductManagement](xref:Moryx.AbstractionLayer.Products.IProductManagement) 
 
 ## Dependencies
 
@@ -24,7 +24,7 @@ None. The product management does not depend on any other server module.
 * [Moryx.Products.Model](xref:Moryx.Products.Model) This data model is used to store product data as well as instance data. The product data describes how to produce an product instance and represents the manufacturing master data while the instance data contains tracing data about every produced instance which is the dynamic data of the product management module.
 
 # Architecture
-The ProductManagement is the central component to manage product types and their instances. Each application can [define custom classes](xref:productDefinition) to best
+The ProductManagement is the central component to manage product types and their instances. Each application can [define custom classes](xref:ProductsDefinition) to best
 meet their requirements. Each application also defines a set of plugins to adapt the product management to their needs.
 
 ## Overview
@@ -32,10 +32,10 @@ meet their requirements. Each application also defines a set of plugins to adapt
 Component name|Implementation|Desription
 --------------|--------------|----------
 [IProductManager](xref:Moryx.Products.Management.IProductManager)|internal|The API of the ProductManager
-[IProductStorage](xref:Moryx.Products.IProductStorage)|external|The plant specific product storage
+[IProductStorage](xref:Moryx.Products.Management.IProductStorage)|external|The plant specific product storage
 [IProductInteraction](xref:Moryx.Products.Management.Modification.IProductInteraction)|internal|Defines teAPI of the product WCF service.
 [IProductConverter](xref:Moryx.Products.Management.Modification.IProductConverter)|internal| *TBD*
-[IProductImporter](xref:Moryx.Products.IProductImporter)|internal/external|Plugins that can import products from file
+[IProductImporter](xref:Moryx.Products.Management.Importers.IProductImporter)|internal/external|Plugins that can import products from file
 [IRecipeManagement](xref:Moryx.Products.Management.IRecipeManagement)|internal|Component to handle all recipe operations
 
 ## Diagrams

--- a/docs/articles/Products/ProductManagementUI.md
+++ b/docs/articles/Products/ProductManagementUI.md
@@ -5,7 +5,7 @@ uid: ProductsUIOverview
 
 The Product UI is responsible to provide all needed information about a product which are devided in its aspects. The Product UI can be extended and also has variable content.
 
-The following posibilities are supported:
+The following possibilities are supported:
 
 - Replace complete detail view
 - Replace only product aspects
@@ -39,11 +39,11 @@ Aspects are presented as `Tabs` whithin the default product detail view. An aspe
 }
 ````
 
-Additionally aspects show/hide themself if they are not relevant. For example: The `PropertiesAspectViewModel` is not *relevant* if the the product have no properties to configure.
+Additionally aspects show/hide themself if they are not relevant. For example: The `PropertiesAspectViewModel` is not *relevant* if the product has no properties to configure.
 
 For adding a custom aspect the [ProductAspectViewModelBase](Moryx.Products.UI.Interaction.Aspects.ProductAspectViewModelBase) can be used to implement an own view model. It provides the whole `IEditableObject` methods and also `Load` and `Save`. It is possible to load additional information from the server with the asynchronous `Load` method.
 
-The following snipped is a sample implementation for the `WatchfaceProduct`:
+The following snippet is a sample implementation for the `WatchfaceProduct`:
 
 ````cs
 [ProductAspectRegistration(nameof(WatchFaceAspectViewModel))]

--- a/docs/articles/Resources/ResourceTypeTree.md
+++ b/docs/articles/Resources/ResourceTypeTree.md
@@ -3,7 +3,7 @@ uid: ResourceTypeTree
 ---
 # Resource type tree
 
-All plugin types within the resource management are derived from the [Resource](xref:Moryx.AbstractionLayer.Resources.Resource) class, either directly or by deriving from a subtype like [PublicResource](xref:Moryx.AbstractionLayer.Resources.PublicResource), [InteractionResource](xref:Moryx.Resources.Interaction.InteractionResource`1) or [Driver](xref:Moryx.AbstractionLayer.Drivers.Driver). 
+All plugin types within the resource management are derived from the [Resource](xref:Moryx.AbstractionLayer.Resources.Resource) class, either directly or by deriving from a subtype like [PublicResource](xref:Moryx.AbstractionLayer.Resources.PublicResource), [InteractionResource](xref:Moryx.Resources.Wcf.InteractionResource) or [Driver](xref:Moryx.AbstractionLayer.Drivers.Driver). 
 Subclassing makes it possible to extend and customize existing resources or share functionality among resources by creating a common, abstract base class. 
 Of those sub-classes `PublicResource` is especially important. 
 The [Resource Management's](xref:ResourceManagement) objective is to model the CPS (cyber physical system) and make it easily accessible to other modules. 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -44,6 +44,12 @@
           "manual/**.md",
           "manual/**/toc.yml"
         ]
+      },
+      {
+        "files": [
+          "migrations/**.md",
+          "migrations/**/toc.yml"
+        ]
       }
     ],
     "resource": [
@@ -61,8 +67,12 @@
     "dest": "_site",
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],
-    "template": ["default"],
-    "postProcessors": ["ExtractSearchIndex"],
+    "template": [
+      "default"
+    ],
+    "postProcessors": [
+      "ExtractSearchIndex"
+    ],
     "noLangKeyword": false,
     "keepFileLink": false,
     "cleanupCacheHistory": false,
@@ -71,7 +81,7 @@
       "_appFooter": "PHOENIXCONTACT - Corporate Technology & Value Chain",
       "_appLogoPath": "resources/Phoenix_Contact_Logo.svg",
       "_enableNewTab": true,
-      "_enableSearch": true      
+      "_enableSearch": true
     }
   }
 }

--- a/docs/manual/ProductUI.md
+++ b/docs/manual/ProductUI.md
@@ -4,11 +4,11 @@ The product management manages all information of a product from the master data
 
 ## Overview
 
-The products ui is structured as a master detail navigation. On the left side, the user can see the complete product structure. If the user click on an item, a product type specific [details view](xref:ProductDetails). will be opened. If no type specific details view was found, the default implementation will be used.
+The products ui is structured as a master detail navigation. On the left side, the user can see the complete product structure. If the user click on an item, a product type specific [details view](#product-details) will be opened. If no type specific details view was found, the default implementation will be used.
 
 ![Product UI](images/productUI.png)
 
-The left structure shows the structure of all availabel products. Each product is shown in the last revision by default. The details can be shown after clicking on a product. The details can be changed by using the `Edit Mode`. The edit mode will be activated after a click on the `Edit` button. All properties inside of the detail view are now open for changes. It is possible that more than one user can edit the details of the product in the same time but only the last save will remain.
+The left structure shows the structure of all available products. Each product is shown in the last revision by default. The details can be shown after clicking on a product. The details can be changed by using the `Edit Mode`. The edit mode will be activated after a click on the `Edit` button. All properties inside of the detail view are now open for changes. It is possible that more than one user can edit the details of the product at the same time but only the last save will remain.
 
 ## Product Details
 
@@ -60,7 +60,7 @@ More important: The part editor provides features to edit part links to other pr
 
 **Single Part Link:**
 
-Single part links must not be set. Therefore a `Clear` button is provided. Another opetion is to change the linked product by `Change`.
+Single part links must not be set. Therefore a `Clear` button is provided. Another option is to change the linked product by `Change`.
 
 ![Single Part Link](images/productUIAspectPartsSingle.png)
 

--- a/docs/manual/ResourceUI.md
+++ b/docs/manual/ResourceUI.md
@@ -1,22 +1,22 @@
 # Resource UI
 
-The Resource UI shows basically all informaiton about the available resources. In context of the Control System there are in most case resources which are representing parts of the production machine like some stations or the drivers to communicate with a PLC. Each resource can be displayed in detail and can be modified.
+The Resource UI shows basically all information about the available resources. In context of the Control System there are in most case resources which are representing parts of the production machine like some stations or the drivers to communicate with a PLC. Each resource can be displayed in detail and can be modified.
 
 ## Overview
 
-All resources will be shown on left side in the tree. Each resource can group some child resources. All details will be displayed after selecting a resource. All informations are grouped in aspects and available with the `Tabs` under the general information area. All information about the selected resource can only be changed in the `Edit Mode` which can be entered with the button on the right bottom corner. The edit mode can be left with the cancel or save button which will restore the old data or save the new data.
+All resources will be shown on left side in the tree. Each resource can group some child resources. All details will be displayed after selecting a resource. All information are grouped in aspects and available with the `Tabs` under the general information area. All information about the selected resource can only be changed in the `Edit Mode` which can be entered with the button on the right bottom corner. The edit mode can be left with the cancel or save button which will restore the old data or save the new data.
 
 ![Resource UI overview](images\resourceUI.png)
 
 ### Delete a resource
 
-To delete a resource just select one and there will be a delete button on the right top corner. The selected resource will be deleted if this button will be clicked and a warning message will be confirmed like in the following picture.
+To delete a resource just select one and there will be a delete button on the right top corner. The selected resource will be deleted if this button will be clicked and a warning message needs to be confirmed like in the following picture.
 
 ![Resource delete dialog](images\resourceUIDeleteDialog.png)
 
 ### Create a new resource
 
-The user can add a new resource with the add button above the resource tree on the left side. A new dialog will be shown with all possible resource types which can be created under the selected resource. So the amount of possible resource can vary by the selected resource. Detailed information like the name and tpe will be displayed on the right side of the dialog. 
+The user can add a new resource with the add button above the resource tree on the left side. A new dialog will be shown with all possible resource types which can be created under the selected resource. So the amount of possible resource can vary by the selected resource. Detailed information like the name and type will be displayed on the right side of the dialog. 
 
 !["Create Dialog"](images\resourceCreateDialog.png)
 
@@ -24,7 +24,7 @@ After pressing the create button, the new resouce will be loaded. The user can e
 
 ### Resource references
 
-Each resource can reference different other resource to work correctly. For example is a reference to an `instructor` necessary to show instructions during the production. All possible references can be shown with the `Reference` tab in the details area. There will be all references on the left and all possible resource which can be used for the selected reference on the right side. To set a reference just select a resource which should be used and click on the `Link Target` button. An indicator will be displayed to show that the resource was linked to the selected reference. This action is only possible in the `Edit Mode`. There are two different types of references. A single reference can only be linked to one resource. A click on the `Link Target` button will automatically unlink an existing link. A multi refernece can be linked to more than one resource. A click on the `Link Target` button will link the selected resrouce and keep the existing links. 
+Each resource can reference different other resource to work correctly. For example is a reference to an `Instructor` necessary to show instructions during the production. All possible references can be shown with the `Reference` tab in the details area. There will be all references on the left and all possible resource which can be used for the selected reference on the right side. To set a reference just select a resource which should be used and click on the `Link Target` button. An indicator will be displayed to show that the resource was linked to the selected reference. This action is only possible in the `Edit Mode`. There are two different types of references. A single reference can only be linked to one resource. A click on the `Link Target` button will automatically unlink an existing link. A multi reference can be linked to more than one resource. A click on the `Link Target` button will link the selected resource and keep the existing links. 
 
 ![Resource references](images\resourceUIAspectReferences.png)
 


### PR DESCRIPTION
This commit fixes some typos in the documentation as well as some broken links