### PR TITLE
Added missing ReplaceOrigin call to set the origin for new recipes

### DIFF
--- a/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
+++ b/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
@@ -126,6 +126,7 @@ namespace Moryx.Products.Management
         {
             ValidateHealthState();
             var recipeId = RecipeManagement.Save(recipe);
+            ReplaceOrigin(recipe);
 
             return recipeId;
         }


### PR DESCRIPTION
The origin of a recipe is null after saving a new created recipe by the ProductManagementFacade.
The origin is set after a restart but further processing of new created recipes can lead to problems with the missing origin.