### PR TITLE
Fixed product import saves partlinks redundant

### DIFF
--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -586,7 +586,12 @@ namespace Moryx.Products.Management
         private ProductTypeEntity GetPartEntity(ProductPartsSaverContext saverContext, IProductPartLink link)
         {
             if (saverContext.EntityCache.ContainsKey((ProductIdentity) link.Product.Identity))
-                return saverContext.EntityCache[(ProductIdentity) link.Product.Identity];
+            {
+                var part = saverContext.EntityCache[(ProductIdentity) link.Product.Identity];
+                EntityIdListener.Listen(part,link.Product);
+                return part;
+            }
+
             if (link.Product.Id == 0)
                 return SaveProduct(saverContext, link.Product);
             return saverContext.UnitOfWork.GetEntity<ProductTypeEntity>(link.Product);

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -10,7 +10,6 @@ using System.Data.Entity;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
-using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Products;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Container;
@@ -586,10 +585,11 @@ namespace Moryx.Products.Management
 
         private ProductTypeEntity GetPartEntity(ref ProductPartsSaverContext saverContext, IProductPartLink link)
         {
-            var product = saverContext.EntityCache.ContainsKey((ProductIdentity)link.Product.Identity)?
-                saverContext.EntityCache[(ProductIdentity)link.Product.Identity] :
-                link.Product.Id == 0 ? SaveProduct(ref saverContext, link.Product) : saverContext.UnitOfWork.GetEntity<ProductTypeEntity>(link.Product);
-            return product;
+            if (saverContext.EntityCache.ContainsKey((ProductIdentity) link.Product.Identity))
+                return saverContext.EntityCache[(ProductIdentity) link.Product.Identity];
+            if (link.Product.Id == 0)
+                return SaveProduct(ref saverContext, link.Product);
+            return saverContext.UnitOfWork.GetEntity<ProductTypeEntity>(link.Product);
         }
 
         /// <summary>

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
@@ -357,6 +357,47 @@ namespace Moryx.Products.IntegrationTests
         }
 
         [Test]
+        public void PartLinksWithTheSameIdentifierAreOnlySavedOnce()
+        {
+           //Arrange
+            var watch = new WatchType
+            {
+                Name = "watch",
+                Identity = new ProductIdentity("223",1),
+                Needles = new List<NeedlePartLink>
+                {
+                    new NeedlePartLink
+                    {
+                        Role = NeedleRole.Minutes,
+                        Product = new NeedleType
+                        {
+                            Identity = new ProductIdentity("222", 0),
+                            Name = "name"
+                        }
+                    },
+                    new NeedlePartLink
+                    {
+                        Role = NeedleRole.Seconds,
+                        Product = new NeedleType
+                        {
+                            Identity = new ProductIdentity("222", 0),
+                            Name = "name"
+                        }
+                    }
+                }
+            };
+
+            //Act
+            _storage.SaveType(watch);
+            var minuteNeedle = watch.Needles.Find(t => t.Role == NeedleRole.Minutes);
+            var secondsNeedle = watch.Needles.Find(t => t.Role == NeedleRole.Seconds);
+
+            //Assert
+            Assert.AreNotEqual(minuteNeedle.Product.Id, 0, "Id of Needle for minutes was 0");
+            Assert.AreEqual(secondsNeedle.Product.Id, 0, "Id of the second needle, which is the same as the first one, has to be 0");
+        }
+
+        [Test]
         public void SaveWatchProduct()
         {
             // Arrange

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
@@ -394,7 +394,8 @@ namespace Moryx.Products.IntegrationTests
 
             //Assert
             Assert.AreNotEqual(minuteNeedle.Product.Id, 0, "Id of Needle for minutes was 0");
-            Assert.AreEqual(secondsNeedle.Product.Id, 0, "Id of the second needle, which is the same as the first one, has to be 0");
+            Assert.AreNotEqual(secondsNeedle.Product.Id, 0, "Id of Needle for seconds was 0");
+            Assert.AreEqual(secondsNeedle.Product.Id, minuteNeedle.Product.Id, "Both needles must have the same Id since they are the same product");
         }
 
         [Test]


### PR DESCRIPTION
Added private class  ProductPartsSaverContext in order to save entities not yet written into the database. 
Closes #64 