### PR TITLE
Added NullPropertyMapper to ignore properties in ProductStorage

### DIFF
--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/NullPropertyMapper.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/NullPropertyMapper.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2021, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Moryx.Container;
+using Moryx.Products.Model;
+
+namespace Moryx.Products.Management
+{
+    /// <summary>
+    /// Null property mapper which does not read or write properties from any column
+    /// </summary>
+    [Component(LifeCycle.Transient, typeof(IPropertyMapper), Name = nameof(NullPropertyMapper))]
+    internal class NullPropertyMapper : IPropertyMapper
+    {
+        private readonly Type _targetType;
+
+        public PropertyInfo Property { get; private set; }
+
+        public NullPropertyMapper(Type targetType)
+        {
+            _targetType = targetType;
+        }
+
+        public void Initialize(PropertyMapperConfig config)
+        {
+            // Retrieve and validate properties
+            Property = _targetType.GetProperty(config.PropertyName);
+        }
+
+        public void Start()
+        {
+
+        }
+
+        public void Stop()
+        {
+        }
+
+        public bool HasChanged(IGenericColumns current, object updated)
+        {
+            return false;
+        }
+
+        public void ReadValue(IGenericColumns source, object target)
+        {
+        }
+
+        public void WriteValue(object source, IGenericColumns target)
+        {
+        }
+
+        public Expression ToColumnExpression(ParameterExpression columnParam, ExpressionType type, object value)
+        {
+            return Expression.Constant(true);
+        }
+    }
+}

--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/PropertyMapper.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/PropertyMapper.cs
@@ -34,6 +34,9 @@ namespace Moryx.Products.Management
         /// </summary>
         protected IPropertyAccessor<IGenericColumns, TColumn> ColumnAccessor { get; private set; }
 
+        /// <summary>
+        /// Creates a new instance of this type
+        /// </summary>
         protected ColumnMapper(Type targetType)
         {
             TargetType = targetType;

--- a/src/Moryx.Products.Samples/ProductTypes/WatchfaceType.cs
+++ b/src/Moryx.Products.Samples/ProductTypes/WatchfaceType.cs
@@ -34,6 +34,9 @@ namespace Moryx.Products.Samples
         [DisplayName("Brand")]
         public string Brand { get; set; }
 
+        [DisplayName("Color")]
+        public int Color { get; set; }
+
         protected override ProductInstance Instantiate()
         {
             return new WatchfaceInstance();

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
@@ -93,6 +93,12 @@ namespace Moryx.Products.IntegrationTests
                                 PropertyName = nameof(WatchfaceType.IsDigital),
                                 Column = nameof(IGenericColumns.Integer1),
                                 PluginName = nameof(IntegerColumnMapper)
+                            },
+                            new PropertyMapperConfig
+                            {
+                                PropertyName = nameof(WatchfaceType.Color),
+                                Column = string.Empty,
+                                PluginName = nameof(NullPropertyMapper)
                             }
                         },
                         JsonColumn = nameof(IGenericColumns.Text8)
@@ -216,6 +222,9 @@ namespace Moryx.Products.IntegrationTests
                             break;
                         case nameof(TextColumnMapper):
                             mapper = new TextColumnMapper(type);
+                            break;
+                        case nameof(NullPropertyMapper):
+                            mapper = new NullPropertyMapper(type);
                             break;
                     }
 
@@ -500,6 +509,28 @@ namespace Moryx.Products.IntegrationTests
             {
                 _storage.SaveType(loaded);
             }, "Save should not fail with null string property");
+        }
+
+        [Test(Description = "This test saves a product with a property which should not be saved. " +
+                            "The NullPropertyMapper ignores this property at load and save.")]
+        public void LoadAndSaveTypeWithNullPropertyMapper()
+        {
+            // Arrange
+            var watchfaceWithString = new WatchfaceType
+            {
+                Name = "Fasel",
+                Identity = new ProductIdentity("55889966", 1),
+                Numbers = new[] { 3, 6, 9, 12 },
+                Brand = "Unknown",
+                Color = 42  //That's important for this test
+            };
+
+            // Act
+            var savedId = _storage.SaveType(watchfaceWithString);
+            var loaded = (WatchfaceType)_storage.LoadType(savedId);
+
+            // Assert
+            Assert.AreEqual(0, loaded.Color);
         }
 
         [TestCase(true, Description = "Get the latest revision of an existing product")]


### PR DESCRIPTION
Added NullPropertyMapper to ignore properties in storage
Closes #83 

This can be merged if 5.4 should be released