### PR TITLE
Fix resource manager event invocation order

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/PublicResource.cs
+++ b/src/Moryx.AbstractionLayer/Resources/PublicResource.cs
@@ -26,8 +26,7 @@ namespace Moryx.AbstractionLayer.Resources
             protected set
             {
                 _capabilities = value;
-                // ReSharper disable once PossibleNullReferenceException <-- Event must always be wired by resource manager
-                CapabilitiesChanged(this, _capabilities);
+                CapabilitiesChanged?.Invoke(this, _capabilities);
             }
         }
 


### PR DESCRIPTION
**Describe the bug**
The resource facade publishes `CapabilitiesChanged` **before** the instance is returned by `GetResources` and publishes `ResourceRemoved` while the resource is still available in `GetResources`.

**To Reproduce**
Steps to reproduce the behavior:
1. Register on one of the events
2. Add or remove resource
3. Call `GetResources` in event handler -> unexpected result

**Expected behavior**
When I receive the event, I expect `GetResources` to match the reported state
