### PR TITLE
Add template id to recipe and reference cloning template

### DIFF
--- a/src/Moryx.AbstractionLayer/Recipes/IRecipeTemplating.cs
+++ b/src/Moryx.AbstractionLayer/Recipes/IRecipeTemplating.cs
@@ -1,0 +1,14 @@
+﻿namespace Moryx.AbstractionLayer.Recipes
+{
+    /// <summary>
+    /// Additional interface for recipe that defines the template/source reference for cloned recipes
+    /// TODO: Integrate this into IRecipe
+    /// </summary>
+    public interface IRecipeTemplating : IRecipe
+    {
+        /// <summary>
+        /// Recipe reference that served as a template for this recipe
+        /// </summary>
+        long TemplateId { get; }
+    }
+}

--- a/src/Moryx.AbstractionLayer/Recipes/Recipe.cs
+++ b/src/Moryx.AbstractionLayer/Recipes/Recipe.cs
@@ -8,7 +8,7 @@ namespace Moryx.AbstractionLayer.Recipes
     /// <summary>
     /// Base class for all recipes
     /// </summary>
-    public abstract class Recipe : IRecipe, ICloneable
+    public abstract class Recipe : IRecipe, ICloneable, IRecipeTemplating
     {
         /// <summary>
         /// Default constructor to create a new recipe
@@ -26,11 +26,18 @@ namespace Moryx.AbstractionLayer.Recipes
             Revision = source.Revision;
             State = source.State;
             Origin = source.Origin;
+
+            TemplateId = source.Id;
             Classification = source.Classification | RecipeClassification.Clone;
         }
 
         /// <inheritdoc />
         public long Id { get; set; }
+
+        /// <summary>
+        /// Optional reference 
+        /// </summary>
+        public long TemplateId { get; set; }
 
         /// <inheritdoc />
         public string Name { get; set; }


### PR DESCRIPTION
To identify the original recipe in case of updates or for other use cases, I included a template id. Because we can not extend the database, this property requires a custom storage mapping in applications that need the recipe id.