### PR TITLE
Fix recipe classification in UI and prevent modification

### DIFF
--- a/src/Moryx.Products.Management/Modification/ProductConverter.cs
+++ b/src/Moryx.Products.Management/Modification/ProductConverter.cs
@@ -157,7 +157,7 @@ namespace Moryx.Products.Management.Modification
                 Properties = EntryConvert.EncodeObject(recipe, RecipeSerialization),
             };
 
-            switch (recipe.Classification)
+            switch (recipe.Classification & RecipeClassification.CloneFilter)
             {
                 case RecipeClassification.Unset:
                     converted.Classification = RecipeClassificationModel.Unset;
@@ -216,6 +216,12 @@ namespace Moryx.Products.Management.Modification
                 productRecipe.Product = productType;
             }
 
+            EntryConvert.UpdateInstance(productRecipe, recipe.Properties, RecipeSerialization);
+
+            // Do not update a clones classification
+            if (productRecipe.Classification.HasFlag(RecipeClassification.Clone))
+                return productRecipe;
+
             switch (recipe.Classification)
             {
                 case RecipeClassificationModel.Unset:
@@ -236,8 +242,6 @@ namespace Moryx.Products.Management.Modification
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-
-            EntryConvert.UpdateInstance(productRecipe, recipe.Properties, RecipeSerialization);
             return productRecipe;
         }
 


### PR DESCRIPTION
For clones the recipe editor always showed `Unset` and what's worse, when saving the recipe it would overwrite the classification in the database and thereby erasing the clone information.

This filters the clone flag from the enum to show the "original" classification and prevents updating a clones classification.

Considering the data corruption caused by this, I suggest releasing it as a 5.4.1 hotfix.