### PR TITLE
Select ResourceAvailableAsAttribute from base classes

### DIFF
--- a/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
@@ -308,7 +308,8 @@ namespace Moryx.Resources.Management
             var relevantInterfaces = new List<Type>(interfaces.Length); // At max all interfaces are relevant
 
             // Load additional public interfaces from resource registration attribute
-            var additionalPublicInterfaces = node.ResourceType.GetCustomAttribute<ResourceAvailableAsAttribute>()?.AvailableAs ?? Enumerable.Empty<Type>();
+            var additionalPublicInterfaces = node.ResourceType.GetCustomAttributes<ResourceAvailableAsAttribute>()
+                .SelectMany(a => a.AvailableAs).Distinct();
 
             // Add all resources derived from IResource, but not IResource itself
             relevantInterfaces.AddRange(from resourceInterface in interfaces


### PR DESCRIPTION
The attribute definition was overridden by inherited classes