### PR TITLE
Fix setting collections through resource proxies

### DIFF
--- a/src/Moryx.Resources.Management/Resources/ResourceProxy.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceProxy.cs
@@ -8,62 +8,24 @@ using Moryx.AbstractionLayer.Resources;
 namespace Moryx.Resources.Management
 {
     /// <summary>
-    /// Hidden interface for <see cref="ResourceProxy{TTarget}"/> to clear
-    /// the reference to the original object
+    /// Base type for all proxies
     /// </summary>
-    internal interface IResourceProxy : IResource
-    {
-        /// <summary>
-        /// Target object of the proxy
-        /// </summary>
-        IResource Target { get; }
-
-        /// <summary>
-        /// Attach to the target object and its events
-        /// </summary>
-        void Attach();
-
-        /// <summary>
-        /// Detach proxy from target object
-        /// </summary>
-        void Detach();
-    }
-
-    /// <summary>
-    /// Resource proxy base for typed access to resources
-    /// </summary>
-    internal abstract class ResourceProxy<TTarget> : IResourceProxy
-        where TTarget : Resource
+    internal abstract class ResourceProxy : IResource
     {
         /// <summary>
         /// Type controller field to convert references to public resources before returning them
         /// </summary>
         private IResourceTypeController _typeController;
 
-        private TTarget _target;
         /// <summary>
-        /// Target resource of this proxy
+        /// Target resource of the proxy
         /// </summary>
-        protected internal TTarget Target
-        {
-            get
-            {
-                if(_target == null)
-                    throw new ProxyDetachedException();
-
-                return _target;
-            }
-            private set { _target = value; }
-        }
-
-
-        /// <inheritdoc />
-        IResource IResourceProxy.Target => Target;
+        public IResource Target { get; private set; }
 
         /// <summary>
         /// Create proxy for a given target
         /// </summary>
-        protected ResourceProxy(TTarget target, IResourceTypeController typeController)
+        protected ResourceProxy(IResource target, IResourceTypeController typeController)
         {
             Target = target;
             _typeController = typeController;
@@ -85,27 +47,65 @@ namespace Moryx.Resources.Management
             Target = null;
         }
 
+        public override string ToString()
+        {
+            return Target.ToString();
+        }
+
         /// <summary>
         /// Convert a referenced instance to a proxy
         /// </summary>
         protected internal TResource Convert<TResource>(IResource instance)
             where TResource : IResource
         {
-            return (TResource) _typeController.GetProxy((Resource) instance);
+            return (TResource)_typeController.GetProxy((Resource)instance);
         }
 
         /// <summary>
         /// Convert a collection of referenced resources to proxies
         /// </summary>
-        protected internal TResource[] ConvertMany<TResource>(IEnumerable<IResource> instances) 
+        protected internal TResource[] ConvertMany<TResource>(IEnumerable<IResource> instances)
             where TResource : IResource
         {
             return instances.Select(Convert<TResource>).ToArray();
         }
 
-        public override string ToString()
+        /// <summary>
+        /// Extract the target object from a proxy
+        /// </summary>
+        protected internal static TResource Extract<TResource>(IResource instance)
+            where TResource : IResource
         {
-            return Target.ToString();
+            var proxy = (ResourceProxy)instance;
+            return (TResource)proxy.Target;
+        }
+
+        /// <summary>
+        /// Extract target objects from collection of proxies
+        /// </summary>
+        protected internal static TResource[] ExtractMany<TResource>(IEnumerable<IResource> instances)
+            where TResource : IResource
+        {
+            return instances.Select(Extract<TResource>).ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Resource proxy base for typed access to resources
+    /// </summary>
+    internal abstract class ResourceProxy<TTarget> : ResourceProxy
+        where TTarget : Resource
+    {
+        /// <summary>
+        /// Typed access to the target field
+        /// </summary>
+        public new TTarget Target => (TTarget) base.Target;
+
+        /// <summary>
+        /// Create proxy for a given target
+        /// </summary>
+        protected ResourceProxy(TTarget target, IResourceTypeController typeController) : base(target, typeController)
+        {
         }
     }
 }

--- a/src/Moryx.Resources.Management/Resources/ResourceProxyBuilder.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceProxyBuilder.cs
@@ -198,15 +198,29 @@ namespace Moryx.Resources.Management
         }
 
         /// <summary>
-        /// Cast the topmost value of the stack to <see cref="IResourceProxy"/> and extract the original resource
+        /// Extract the resource target from the topmost proxy value on the stack
         /// </summary>
         private static void ExtractTargetFromStack(ILGenerator generator, Type targetType)
         {
-            var interfaceType = typeof(IResourceProxy);
-            generator.Emit(OpCodes.Castclass, interfaceType); // Cast value to proxy
-            var proxyTarget = interfaceType.GetProperty(nameof(IResourceProxy.Target)).GetMethod;
-            generator.Emit(OpCodes.Call, proxyTarget); // Call getter on Proxy.Target to load the real resource on the stack
-            generator.Emit(OpCodes.Castclass, targetType); // Cast resource to the property type
+            // Target field for property and method forwarding
+            Type elementType;
+            string methodName;
+            if (typeof(IResource).IsAssignableFrom(targetType))
+            {
+                elementType = targetType;
+                methodName = nameof(ResourceProxy.Extract);
+            }
+            else
+            {
+                elementType = targetType.IsArray
+                    ? targetType.GetElementType()
+                    : targetType.GetGenericArguments()[0];
+                methodName = nameof(ResourceProxy.ExtractMany);
+            }
+
+            var methodInfo = typeof(ResourceProxy).GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
+            methodInfo = methodInfo.MakeGenericMethod(elementType);
+            generator.Emit(OpCodes.Call, methodInfo);
         }
 
         /// <summary>
@@ -276,14 +290,14 @@ namespace Moryx.Resources.Management
             if (typeof(IResource).IsAssignableFrom(propertyType))
             {
                 elementType = propertyType;
-                methodName = nameof(ResourceProxy<PublicResource>.Convert);
+                methodName = nameof(ResourceProxy.Convert);
             }
             else
             {
                 elementType = propertyType.IsArray
                     ? propertyType.GetElementType()
                     : propertyType.GetGenericArguments()[0];
-                methodName = nameof(ResourceProxy<PublicResource>.ConvertMany);
+                methodName = nameof(ResourceProxy.ConvertMany);
             }
             var methodInfo = baseType.GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
             return methodInfo.MakeGenericMethod(elementType);
@@ -372,16 +386,16 @@ namespace Moryx.Resources.Management
         }
 
         /// <summary>
-        /// Override <see cref="ResourceProxy{T}.Attach"/> and register event handlers
+        /// Override <see cref="ResourceProxy.Attach"/> and register event handlers
         /// </summary>
         private static void OverrideAttach(TypeBuilder typeBuilder, Type baseType, MethodInfo targetGetter, Type targetType, Dictionary<EventInfo, MethodBuilder> eventHandlers)
         {
             var methodAttributes = MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig;
-            var methodBuilder = typeBuilder.DefineMethod(nameof(IResourceProxy.Attach), methodAttributes, typeof(void), Type.EmptyTypes);
+            var methodBuilder = typeBuilder.DefineMethod(nameof(ResourceProxy.Attach), methodAttributes, typeof(void), Type.EmptyTypes);
 
             var generator = methodBuilder.GetILGenerator();
             generator.Emit(OpCodes.Ldarg_0); // Load 'this'
-            var baseAttach = baseType.GetMethod(nameof(IResourceProxy.Attach));
+            var baseAttach = baseType.GetMethod(nameof(ResourceProxy.Attach));
             generator.Emit(OpCodes.Call, baseAttach); // Non-virtual call on base.Attach()
             // Link event handler for each event on the target object
             foreach (var eventHandler in eventHandlers)
@@ -404,12 +418,12 @@ namespace Moryx.Resources.Management
         }
 
         /// <summary>
-        /// Override <see cref="ResourceProxy{T}.Detach"/> and unregister event handlers
+        /// Override <see cref="ResourceProxy.Detach"/> and unregister event handlers
         /// </summary>
         private static void OverrideDetach(TypeBuilder typeBuilder, Type baseType, MethodInfo targetGetter, Type targetType, Dictionary<EventInfo, MethodBuilder> eventHandlers)
         {
             var methodAttributes = MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.HideBySig;
-            var methodBuilder = typeBuilder.DefineMethod(nameof(IResourceProxy.Detach), methodAttributes, typeof(void), Type.EmptyTypes);
+            var methodBuilder = typeBuilder.DefineMethod(nameof(ResourceProxy.Detach), methodAttributes, typeof(void), Type.EmptyTypes);
 
             var generator = methodBuilder.GetILGenerator();
             // Unregister event handler for each event on the target object
@@ -431,7 +445,7 @@ namespace Moryx.Resources.Management
 
             // Call base.Detach()
             generator.Emit(OpCodes.Ldarg_0); // Load 'this'
-            var baseAttach = baseType.GetMethod(nameof(IResourceProxy.Detach));
+            var baseAttach = baseType.GetMethod(nameof(ResourceProxy.Detach));
             generator.Emit(OpCodes.Call, baseAttach); // Non-virtual call on base.Attach()
 
             generator.Emit(OpCodes.Ret); // Finish method

--- a/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceTypeController.cs
@@ -43,7 +43,7 @@ namespace Moryx.Resources.Management
         /// Cache of all proxy instances that were created during the runtime of the ResourceManagement. They
         /// all need to be
         /// </summary>
-        private readonly Dictionary<long, IResourceProxy> _proxyCache = new Dictionary<long, IResourceProxy>();
+        private readonly Dictionary<long, ResourceProxy> _proxyCache = new Dictionary<long, ResourceProxy>();
 
         /// <summary>
         /// Cache to directly access a resource type
@@ -252,10 +252,10 @@ namespace Moryx.Resources.Management
         /// <summary>
         /// Instantiate proxy object for a given resource type name
         /// </summary>
-        private IResourceProxy InstantiateProxy(string typeName, Resource instance)
+        private ResourceProxy InstantiateProxy(string typeName, Resource instance)
         {
             var proxyType = ProxyBuilder.GetType(_proxyTypeCache[typeName]);
-            var proxyInstance = (IResourceProxy)Activator.CreateInstance(proxyType, instance, this);
+            var proxyInstance = (ResourceProxy)Activator.CreateInstance(proxyType, instance, this);
             proxyInstance.Attach();
             return proxyInstance;
         }

--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/ReferenceResource.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/ReferenceResource.cs
@@ -23,6 +23,8 @@ namespace Moryx.Resources.Management.Tests
 
         void SetReference(ISimpleResource reference);
 
+        void SetMany(IReadOnlyList<ISimpleResource> references);
+
         event EventHandler<ISimpleResource> ReferenceChanged;
 
         event EventHandler<ISimpleResource[]> SomeChanged;
@@ -84,6 +86,13 @@ namespace Moryx.Resources.Management.Tests
         {
             References.Add(reference);
         }
+
+        public void SetMany(IReadOnlyList<ISimpleResource> references)
+        {
+            foreach (var reference in references)
+                References.Add(reference);
+        }
+
 
         public INonPublicResource NonPublic { get; set; }
 

--- a/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
@@ -228,6 +228,7 @@ namespace Moryx.Resources.Management.Tests
             // Act: Set resource property through proxy
             proxy.Reference = references[0];
             proxy.SetReference(reference);
+            proxy.SetMany(references);
 
             // Make sure all references where replaced with proxies
             Assert.AreNotEqual(ref1, reference);
@@ -246,7 +247,7 @@ namespace Moryx.Resources.Management.Tests
             Assert.AreEqual("NonPublic", nonPubProxy.Name);
             // Assert modifications of the setters
             Assert.AreEqual(instance.Reference, ref2);
-            Assert.AreEqual(instance.References.Count(), 2);
+            Assert.AreEqual(instance.References.Count(), 4);
             Assert.AreEqual(instance.References.ElementAt(1), ref1);
         }
 


### PR DESCRIPTION
While the ProxyBuilder did generate code for setting collections of resources, this code always assumed the argument was a single reference and failed with a type caste exception when executed for collections.