### PR TITLE
Accessible name on TaskTransition

### DIFF
--- a/src/Moryx.AbstractionLayer/Tasks/TaskTransition.cs
+++ b/src/Moryx.AbstractionLayer/Tasks/TaskTransition.cs
@@ -31,7 +31,7 @@ namespace Moryx.AbstractionLayer
         /// <summary>
         /// Name of the task
         /// </summary>
-        internal string Name { get; set; }
+        public string Name { get; internal set; }
 
         /// <summary>
         /// Create a new instance of the <see cref="TaskTransition{T}"/>


### PR DESCRIPTION
In #77 we added a name to tasks and activities, which are passed through the transition in an internal field. During workflow execution we don't have access to the task and might not yet have an activity, so we need the name on the transition.