### PR TITLE
Removed filter to allow serialization of properties without a setter

### DIFF
--- a/src/Moryx.Products.Management/Modification/PartialSerialization.cs
+++ b/src/Moryx.Products.Management/Modification/PartialSerialization.cs
@@ -39,10 +39,6 @@ namespace Moryx.Products.Management.Modification
 
         protected bool SimpleProp(PropertyInfo prop)
         {
-            // Check if property can be written
-            if (prop.SetMethod == null)
-                return false;
-
             // Skip reference or domain model properties
             var type = prop.PropertyType;
             if (type == typeof(ProductFile) ||


### PR DESCRIPTION
There was a filter in PartialSerialization which avoids properties without a setter. There are cases where these properties are necessary to be serialized to get them even if they can not be changed.