### PR TITLE
Refresh also refreshes the currently selected resource

### DIFF
--- a/src/Moryx.Resources.Samples/RefreshResource.cs
+++ b/src/Moryx.Resources.Samples/RefreshResource.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using Moryx.AbstractionLayer.Resources;
+using Moryx.Serialization;
+
+namespace Moryx.Resources.Samples
+{
+    public class RefreshResource : Resource
+    {
+        [EntrySerialize]
+        public string CurrentTime => DateTime.Now.ToLongTimeString();
+    }
+}

--- a/src/Moryx.Resources.UI.Interaction/Workspace/InteractionWorkspaceViewModel.cs
+++ b/src/Moryx.Resources.UI.Interaction/Workspace/InteractionWorkspaceViewModel.cs
@@ -218,6 +218,9 @@ namespace Moryx.Resources.UI.Interaction
             IsBusy = true;
 
             await UpdateTreeAsync();
+            
+            if (SelectedResource != null)
+                await SelectResource(SelectedResource);
 
             IsBusy = false;
         }


### PR DESCRIPTION
While the product UI already implements that behavior, it was missing in the resource UI. Considering how often resources update fields in production and how seldom that is for products, I was a little suprised.

I added a `RefreshResource` to the samples, wich allows for easy testing of the functionality.

Closes #107 

FYI: @leopoldHatFertig 