### PR TITLE
Bugfix/load highest revision from product storage

### DIFF
--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -368,7 +368,7 @@ namespace Moryx.Products.Management
                 {
                     // Get all revisions of this product
                     var revisions = productRepo.Linq
-                        .Where(p => p.Identifier == identity.Identifier)
+                        .Where(p => p.Identifier == identity.Identifier && p.Deleted != null)
                         .Select(p => p.Revision).ToList();
                     if (revisions.Any())
                         revision = revisions.Max();


### PR DESCRIPTION
Before this bugfix the method returned null, if you wanted to load the highest revision of a product and this revision was deleted.