### PR TITLE
Fixed name of logger in resource initialization

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/Resource.cs
+++ b/src/Moryx.AbstractionLayer/Resources/Resource.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using System;
@@ -61,7 +61,8 @@ namespace Moryx.AbstractionLayer.Resources
         /// <inheritdoc />
         void IInitializable.Initialize()
         {
-            Logger = Logger?.GetChild(Name, GetType());
+            var loggerName = Name.Replace(".", "_"); // replace . with _ because of logger child structure
+            Logger = Logger?.GetChild(loggerName, GetType());
             OnInitialize();
         }
 


### PR DESCRIPTION
Logger should not use dots in name because the dot will be used to structure the logger tree.