### PR TITLE
Lock the classification dropdown in the DefaultRecipeView for Cloned Recipes

### DIFF
--- a/src/Moryx.Products.Management/Modification/Endpoint/IProductInteraction.cs
+++ b/src/Moryx.Products.Management/Modification/Endpoint/IProductInteraction.cs
@@ -14,7 +14,7 @@ namespace Moryx.Products.Management.Modification
 {
 #if USE_WCF
     [ServiceContract]
-    [ServiceVersion("5.0.0")]
+    [ServiceVersion("5.1.0")]
 #endif
     internal interface IProductInteraction
     {

--- a/src/Moryx.Products.Management/Modification/Model/RecipeModel.cs
+++ b/src/Moryx.Products.Management/Modification/Model/RecipeModel.cs
@@ -62,5 +62,11 @@ namespace Moryx.Products.Management.Modification
         /// </summary>
         [DataMember]
         public RecipeClassificationModel Classification { get; set; }
+
+        /// <summary>
+        /// Whether this Recipe is a clone or not
+        /// </summary>
+        [DataMember]
+        public bool IsClone{ get; set; }
     }
 }

--- a/src/Moryx.Products.Management/Modification/ProductConverter.cs
+++ b/src/Moryx.Products.Management/Modification/ProductConverter.cs
@@ -155,6 +155,7 @@ namespace Moryx.Products.Management.Modification
                 State = recipe.State,
                 Revision = recipe.Revision,
                 Properties = EntryConvert.EncodeObject(recipe, RecipeSerialization),
+                IsClone = recipe.Classification.HasFlag(RecipeClassification.Clone)
             };
 
             switch (recipe.Classification & RecipeClassification.CloneFilter)

--- a/src/Moryx.Products.UI.Interaction/Recipes/Details/Default/DefaultRecipeDetailsView.xaml
+++ b/src/Moryx.Products.UI.Interaction/Recipes/Details/Default/DefaultRecipeDetailsView.xaml
@@ -70,8 +70,19 @@
                                     SharedSizeGroupName="EditRecipe"
                                     Margin="0,0,0,5">
                     <EddieComboBox ItemsSource="{Binding Source={StaticResource RecipeClassificationValues}}"
-                                   SelectedItem="{Binding EditableObject.Classification, Mode=TwoWay}"
-                                   IsEnabled="{Binding IsEditMode}">
+                                   SelectedItem="{Binding EditableObject.Classification, Mode=TwoWay}">
+                        <EddieComboBox.Style>
+                            <Style TargetType="EddieComboBox">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding EditableObject.IsClone}" Value="true">
+                                        <Setter Property="IsEnabled" Value="False"/>
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding IsEditMode}" Value="false">
+                                        <Setter Property="IsEnabled" Value="False"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </EddieComboBox.Style>
                     </EddieComboBox>
                 </LabeledControlHost>
 

--- a/src/Moryx.Products.UI.Interaction/Recipes/Details/Default/DefaultRecipeDetailsViewModel.cs
+++ b/src/Moryx.Products.UI.Interaction/Recipes/Details/Default/DefaultRecipeDetailsViewModel.cs
@@ -8,6 +8,5 @@ namespace Moryx.Products.UI.Interaction
     [RecipeDetailsRegistration(DetailsConstants.DefaultType)]
     internal class DefaultRecipeDetailsViewModel : RecipeDetailsViewModelBase
     {
-
     }
 }

--- a/src/Moryx.Products.UI/Connected Services/ProductService/Reference.cs
+++ b/src/Moryx.Products.UI/Connected Services/ProductService/Reference.cs
@@ -1071,6 +1071,8 @@ namespace Moryx.Products.UI.ProductService
         
         private long IdField;
         
+        private bool IsCloneField;
+        
         private string NameField;
         
         private Moryx.Products.UI.ProductService.Entry PropertiesField;
@@ -1106,6 +1108,19 @@ namespace Moryx.Products.UI.ProductService
             set
             {
                 this.IdField = value;
+            }
+        }
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public bool IsClone
+        {
+            get
+            {
+                return this.IsCloneField;
+            }
+            set
+            {
+                this.IsCloneField = value;
             }
         }
         

--- a/src/Moryx.Products.UI/ProductServiceModel.cs
+++ b/src/Moryx.Products.UI/ProductServiceModel.cs
@@ -22,7 +22,7 @@ namespace Moryx.Products.UI
         public override string ServiceName => nameof(IProductInteraction);
 
         /// <inheritdoc />
-        protected override string ClientVersion => "5.0.0";
+        protected override string ClientVersion => "5.1.0";
 
         /// <inheritdoc />
         public ProductServiceModel(IWcfClientFactory clientFactory, IModuleLogger logger)

--- a/src/Moryx.Products.UI/ViewModels/RecipeViewModel.cs
+++ b/src/Moryx.Products.UI/ViewModels/RecipeViewModel.cs
@@ -19,6 +19,7 @@ namespace Moryx.Products.UI
         private string _type;
         private int _revision;
         private RecipeClassificationModel _classification;
+        private bool _isClone;
 
         private WorkplanViewModel _workplan;
         private EntryViewModel _properties;
@@ -105,6 +106,19 @@ namespace Moryx.Products.UI
         }
 
         /// <summary>
+        /// Gets whether this recipe is a clone
+        /// </summary>
+        public bool IsClone
+        {
+            get { return _isClone; }
+            set
+            {
+                _isClone = value;
+                NotifyOfPropertyChange(nameof(IsClone));
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the revision of the recipe
         /// </summary>
         public int Revision
@@ -138,6 +152,7 @@ namespace Moryx.Products.UI
             Name = Model.Name;
             Type = Model.Type;
             Classification = Model.Classification;
+            IsClone = Model.IsClone;
             Revision = Model.Revision;
             Properties = new EntryViewModel(Model.Properties.ToSerializationEntry());
         }
@@ -150,6 +165,7 @@ namespace Moryx.Products.UI
             Model.Name = _name;
             Model.Type = _type;
             Model.Classification = _classification;
+            Model.IsClone = _isClone;
             Model.Revision = _revision;
             Model.Properties = Properties.Entry.ToServiceEntry();
             Model.WorkplanId = Workplan?.Id ?? 0;


### PR DESCRIPTION
63b5c07a4742ae82661fb4095a555ca957767142 added a fix that prevents the classification of such cloned recipes to be changed within the UI.

This PR adapts the default recipe UI to lock the dropdown menu for changing the classification in order to make the implemented behaviour transparent for the User.

