### PR TITLE
Implemented possibility to show a product type tree if configured

### DIFF
--- a/src/Moryx.Products.UI.Interaction/ModuleController/ModuleConfig.cs
+++ b/src/Moryx.Products.UI.Interaction/ModuleController/ModuleConfig.cs
@@ -66,5 +66,11 @@ namespace Moryx.Products.UI.Interaction
         /// </summary>
         [DataMember]
         public List<AspectConfiguration> DefaultAspects { get; set; }
+
+        /// <summary>
+        /// Set to true to show the product types as a tree instead of a flat list
+        /// </summary>
+        [DataMember]
+        public bool ShowProductTypeTree { get; set; }
     }
 }


### PR DESCRIPTION
The product ui currently shows the product types as a flat list even if they derive from each other.
It is enough for small numbers of ProductTypes but if you have many ProductTypes it can become confusing.
For this case i extended the ModuleConfig of the products ui interaction to have the possibility to choose between a flat list or a tree. The tree option will consider the derivation. In this case you can add some ProductTypes to groupt your types and make the product overview more clearer.

Before: 
![image](https://user-images.githubusercontent.com/16089808/144852577-c34616bd-5f3e-40bd-86d5-515c45919640.png)

After + some grouping types:
![image](https://user-images.githubusercontent.com/16089808/144852797-721cb896-559f-4849-8e36-783bd904bdcc.png)

