### PR TITLE
Add Unit tests for ProductConverter and Bug Fixes

### DIFF
--- a/AbstractionLayer.sln
+++ b/AbstractionLayer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.352
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StartProject", "src\StartProject\StartProject.csproj", "{08B7686D-63C7-498C-90F0-B756E93575DD}"
 EndProject
@@ -44,6 +44,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.AbstractionLayer.TestTools", "src\Moryx.AbstractionLayer.TestTools\Moryx.AbstractionLayer.TestTools.csproj", "{1516374C-976F-49FC-A911-29EDC481C657}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Resources.Wcf", "src\Moryx.Resources.Wcf\Moryx.Resources.Wcf.csproj", "{E1AD28CD-37A6-4AF6-80D7-756586A727B6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moryx.Products.Management.Tests", "src\Tests\Moryx.Products.Management.Tests\Moryx.Products.Management.Tests.csproj", "{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -111,6 +113,10 @@ Global
 		{E1AD28CD-37A6-4AF6-80D7-756586A727B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E1AD28CD-37A6-4AF6-80D7-756586A727B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1AD28CD-37A6-4AF6-80D7-756586A727B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -130,6 +136,7 @@ Global
 		{93650069-26E9-4E0D-A336-9D02F1039346} = {D6D69517-7889-4E08-ABEA-D3E069D08A6B}
 		{583CBD84-DD9F-4834-A89C-1625A05EE15D} = {BA183EBF-FAC1-45AE-9559-09879DB103AC}
 		{E1AD28CD-37A6-4AF6-80D7-756586A727B6} = {BA183EBF-FAC1-45AE-9559-09879DB103AC}
+		{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD} = {D6D69517-7889-4E08-ABEA-D3E069D08A6B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {23463631-1BA0-41B8-ABA3-1E9741037513}

--- a/src/Moryx.AbstractionLayer.TestTools/DummyProductPartLink.cs
+++ b/src/Moryx.AbstractionLayer.TestTools/DummyProductPartLink.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Products;
+using System.Linq;
+
+namespace Moryx.AbstractionLayer.TestTools
+{
+    /// <summary>
+    /// Dummy implementation of a ProductPartLink.
+    /// </summary>
+    public class DummyProductPartLink : ProductPartLink<DummyProductType>
+    {
+        public override bool Equals(object obj)
+        {
+            var toCompareWith = obj as DummyProductPartLink;
+            if (toCompareWith == null)
+                return false;
+            
+            return GetType().GetProperties()
+                .All(prop => (prop.GetValue(toCompareWith) is null && prop.GetValue(this) is null)
+                            || prop.GetValue(toCompareWith).Equals(prop.GetValue(this)));
+        }
+    }
+}

--- a/src/Moryx.AbstractionLayer.TestTools/DummyProductRecipe.cs
+++ b/src/Moryx.AbstractionLayer.TestTools/DummyProductRecipe.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Recipes;
+using Moryx.Workflows;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Moryx.AbstractionLayer.TestTools
+{
+    /// <summary>
+    /// Dummy implementation of an product instance. Created by the <see cref="DummyProductType"/>
+    /// </summary>
+    public class DummyProductRecipe : ProductRecipe
+    {
+        public override bool Equals(object obj)
+        {
+            var toCompareWith = obj as DummyProductRecipe;
+            if (toCompareWith == null)
+                return false;
+
+            return toCompareWith.Name == Name && toCompareWith.Revision == Revision 
+                && toCompareWith.State == State && toCompareWith.Classification == Classification 
+                && ((toCompareWith.Origin is null && Origin is null) || Origin.Equals(toCompareWith.Origin))
+                && ((toCompareWith.Product is null && Product is null) || Product.Equals(toCompareWith.Product))
+                && ((toCompareWith.Target is null && Target is null) || Target.Equals(toCompareWith.Target));
+        }
+    }
+
+    public class DummyProductWorkplanRecipe : DummyProductRecipe, IWorkplanRecipe
+    {
+        public IWorkplan Workplan { get; set; }
+
+        public ICollection<long> DisabledSteps { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var toCompareWith = obj as DummyProductWorkplanRecipe;
+            if (toCompareWith == null)
+                return false;
+
+            return base.Equals(toCompareWith) 
+                && ((toCompareWith.Workplan is null && Workplan is null) || Workplan.Equals(toCompareWith.Workplan))
+                && ((toCompareWith.DisabledSteps is null && DisabledSteps is null) || Enumerable.SequenceEqual<long>(DisabledSteps, toCompareWith.DisabledSteps));
+        }
+    }
+}

--- a/src/Moryx.AbstractionLayer.TestTools/DummyProductType.cs
+++ b/src/Moryx.AbstractionLayer.TestTools/DummyProductType.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Products;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Moryx.AbstractionLayer.TestTools
 {
@@ -14,6 +16,88 @@ namespace Moryx.AbstractionLayer.TestTools
         protected override ProductInstance Instantiate()
         {
             return new DummyProductInstance();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var toCompareWith = obj as DummyProductType;
+            if (toCompareWith == null)
+                return false;
+
+            return toCompareWith.Id == Id && toCompareWith.Name == Name && toCompareWith.State == State 
+                && ((toCompareWith.Identity is null && Identity is null) || toCompareWith.Identity.Equals(Identity));
+        }
+    }
+
+
+    /// <summary>
+    /// Dummy implementation of a <see cref="ProductType"/> with Product Parts 
+    /// </summary>
+    public class DummyProductTypeWithParts : DummyProductType
+    {
+        /// <inheritdoc />
+        protected override ProductInstance Instantiate()
+        {
+            return new DummyProductInstance();
+        }
+
+        /// <summary>
+        /// Dummy ProductPartLink
+        /// </summary>
+        public DummyProductPartLink ProductPartLink { get; set; }
+
+        /// <summary>
+        /// Dummy ProductPartLink enumerable
+        /// </summary>
+        public IEnumerable<DummyProductPartLink> ProductPartLinkEnumerable { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var toCompareWith = obj as DummyProductTypeWithParts;
+            if (toCompareWith == null)
+                return false;
+
+            return base.Equals(toCompareWith) && 
+                ((toCompareWith.ProductPartLink is null && ProductPartLink is null) || 
+                toCompareWith.ProductPartLink.Equals(ProductPartLink))
+                && ((toCompareWith.ProductPartLinkEnumerable is null && ProductPartLinkEnumerable is null) || 
+                Enumerable.SequenceEqual<DummyProductPartLink>(toCompareWith.ProductPartLinkEnumerable, ProductPartLinkEnumerable));
+        }
+    }
+
+
+    /// <summary>
+    /// Dummy implementation of a <see cref="ProductType"/> with Files
+    /// </summary>
+    public class DummyProductTypeWithFiles : DummyProductType
+    {
+        /// <inheritdoc />
+        protected override ProductInstance Instantiate()
+        {
+            return new DummyProductInstance();
+        }
+
+        /// <summary>
+        /// First dummy ProductFile
+        /// </summary>
+        public ProductFile FirstProductFile { get; set; }
+
+        /// <summary>
+        /// Second dummy ProductFile
+        /// </summary>
+        public ProductFile SecondProductFile { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            var toCompareWith = obj as DummyProductTypeWithFiles;
+            if (toCompareWith == null)
+                return false;
+
+            return base.Equals(toCompareWith) &&
+                (toCompareWith.FirstProductFile is null && FirstProductFile is null ||
+                FirstProductFile.GetType().GetProperties().All(prop => prop.GetValue(toCompareWith.FirstProductFile) == prop.GetValue(FirstProductFile)))
+                && (toCompareWith.SecondProductFile is null && SecondProductFile is null ||
+                SecondProductFile.GetType().GetProperties().All(prop => prop.GetValue(toCompareWith.SecondProductFile) == prop.GetValue(SecondProductFile)));
         }
     }
 }

--- a/src/Moryx.AbstractionLayer.TestTools/DummyWorkplan.cs
+++ b/src/Moryx.AbstractionLayer.TestTools/DummyWorkplan.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.Workflows;
+using System.Linq;
+
+namespace Moryx.AbstractionLayer.TestTools
+{
+    public class DummyWorkplan : Workplan
+    {
+        public override bool Equals(object obj)
+        {
+            var toCompareWith = obj as DummyWorkplan;
+            if (toCompareWith == null)
+                return false;
+
+            return toCompareWith.Id == Id && toCompareWith.Name == Name 
+                && toCompareWith.Version == toCompareWith.Version && toCompareWith.State == State
+                && ((toCompareWith.Connectors is null && Connectors is null) || Enumerable.SequenceEqual(toCompareWith.Connectors, Connectors))
+                && ((toCompareWith.Steps is null && Steps is null) || Enumerable.SequenceEqual(toCompareWith.Steps, Steps)); 
+        }
+    }
+}

--- a/src/Moryx.AbstractionLayer/Products/ProductType.cs
+++ b/src/Moryx.AbstractionLayer/Products/ProductType.cs
@@ -30,7 +30,7 @@ namespace Moryx.AbstractionLayer.Products
         /// </returns>
         public override string ToString()
         {
-            return Identity.ToString();
+            return Identity?.ToString();
         }
 
         /// <summary>

--- a/src/Moryx.Products.Management/Modification/Model/ProductFileModel.cs
+++ b/src/Moryx.Products.Management/Modification/Model/ProductFileModel.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Runtime.Serialization;
+
+namespace Moryx.Products.Management.Modification
+{
+    [DataContract]
+    internal class ProductFileModel
+    {
+        [DataMember]
+        public string PropertyName { get; set; }
+
+        [DataMember]
+        public string FileName { get; set; }
+
+        [DataMember]
+        public string MimeType { get; set; }
+
+        [DataMember]
+        public string FilePath { get; set; }
+
+        [DataMember]
+        public string FileHash { get; set; }
+    }
+}

--- a/src/Moryx.Products.Management/Modification/Model/ProductModel.cs
+++ b/src/Moryx.Products.Management/Modification/Model/ProductModel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Runtime.Serialization;
 using Moryx.AbstractionLayer.Products;
 using Moryx.Serialization;
@@ -31,8 +32,13 @@ namespace Moryx.Products.Management.Modification
         [DataMember]
         public Entry Properties { get; set; }
 
+        // TODO: AL6 Remove Files and rename FileModels to Files
         [DataMember]
+        [Obsolete("Use FileModels Instead")]
         public ProductFile[] Files { get; set; }
+
+        [DataMember]
+        public ProductFileModel[] FileModels { get; set; }
 
         [DataMember]
         public PartConnector[] Parts { get; set; }

--- a/src/Moryx.Products.Management/Modification/ProductConverter.cs
+++ b/src/Moryx.Products.Management/Modification/ProductConverter.cs
@@ -62,7 +62,10 @@ namespace Moryx.Products.Management.Modification
             converted.Properties = EntryConvert.EncodeObject(productType, ProductSerialization);
 
             // Files
-            converted.Files = ConvertFiles(productType, properties);
+            converted.Files = (from property in properties
+                               where property.PropertyType == typeof(ProductFile)
+                               select (ProductFile)property.GetValue(productType)).ToArray();
+            converted.FileModels = ConvertFiles(productType, properties);
 
             // Recipes
             var recipes = RecipeManagement.GetAllByProduct(productType);
@@ -85,12 +88,23 @@ namespace Moryx.Products.Management.Modification
             };
         }
 
-        private static ProductFile[] ConvertFiles(IProductType productType, IEnumerable<PropertyInfo> properties)
+        private ProductFileModel[] ConvertFiles(IProductType productType, IEnumerable<PropertyInfo> properties)
         {
-            var files = (from property in properties
-                         where property.PropertyType == typeof(ProductFile)
-                         select (ProductFile)property.GetValue(productType)).ToArray();
-            return files;
+            var productFileProperties = properties.Where(p => p.PropertyType == typeof(ProductFile)).ToArray();
+            var fileModels = new ProductFileModel[productFileProperties.Length];
+            for (int i = 0; i < fileModels.Length; i++)
+            {
+                var value = (ProductFile)productFileProperties[i].GetValue(productType);
+                fileModels[i] = new ProductFileModel()
+                {
+                    PropertyName = productFileProperties[i].Name,
+                    FileName = value?.Name,
+                    FileHash = value?.FileHash,
+                    FilePath = value?.FilePath,
+                    MimeType = value?.MimeType
+                };
+            }
+            return fileModels;
         }
 
         private void ConvertParts(IProductType productType, IEnumerable<PropertyInfo> properties, ProductModel converted)
@@ -109,7 +123,7 @@ namespace Moryx.Products.Management.Modification
                         Name = property.Name,
                         DisplayName = displayName,
                         Type = FetchProductType(property.PropertyType),
-                        Parts = partModel != null ? new[] { partModel } : new PartModel[0],
+                        Parts = partModel is null ? new PartModel[0] : new[] { partModel },
                         PropertyTemplates = EntryConvert.EncodeClass(property.PropertyType, ProductSerialization)
                     };
                     connectors.Add(connector);
@@ -124,7 +138,7 @@ namespace Moryx.Products.Management.Modification
                         Name = property.Name,
                         DisplayName = displayName,
                         Type = FetchProductType(linkType),
-                        Parts = links.Select(ConvertPart).ToArray(),
+                        Parts = links?.Select(ConvertPart).ToArray(),
                         PropertyTemplates = EntryConvert.EncodeClass(linkType, ProductSerialization)
                     };
                     connectors.Add(connector);
@@ -136,7 +150,7 @@ namespace Moryx.Products.Management.Modification
         private PartModel ConvertPart(IProductPartLink link)
         {
             // No link, no DTO!
-            if (link == null)
+            if (link is null || link.Product is null)
                 return null;
 
             var part = new PartModel
@@ -262,16 +276,10 @@ namespace Moryx.Products.Management.Modification
             converted.Identity = new ProductIdentity(source.Identifier, source.Revision);
             converted.Name = source.Name;
             converted.State = source.State;
-
-            // Copy extended properties
-            var properties = converted.GetType().GetProperties();
-            EntryConvert.UpdateInstance(converted, source.Properties, ProductSerialization);
-
-            ConvertFilesBack(converted, source, properties);
-
+            
             // Save recipes
-            var recipes = new List<IProductRecipe>(source.Recipes.Length);
-            foreach (var recipeModel in source.Recipes)
+            var recipes = new List<IProductRecipe>(source.Recipes?.Length ?? 0);
+            foreach (var recipeModel in source.Recipes ?? Enumerable.Empty<RecipeModel>())
             {
                 IProductRecipe productRecipe;
                 if (recipeModel.Id == 0)
@@ -285,15 +293,36 @@ namespace Moryx.Products.Management.Modification
                 ConvertRecipeBack(recipeModel, productRecipe, converted);
                 recipes.Add(productRecipe);
             }
-            RecipeManagement.Save(source.Id, recipes);
+            if (recipes.Any())
+                RecipeManagement.Save(source.Id, recipes);
+
+            // Product is flat
+            if (source.Properties is null)
+                return converted;
+
+            // Copy extended properties
+            var properties = converted.GetType().GetProperties();
+            EntryConvert.UpdateInstance(converted, source.Properties, ProductSerialization);
+
+            // Copy Files
+            ConvertFilesBack(converted, source, properties);
 
             // Convert parts
-            foreach (var partConnector in source.Parts)
+            foreach (var partConnector in source.Parts ?? Enumerable.Empty<PartConnector>())
             {
+                if (partConnector.Parts is null)
+                    continue;
+
                 var prop = properties.First(p => p.Name == partConnector.Name);
                 var value = prop.GetValue(converted);
                 if (partConnector.IsCollection)
                 {
+                    if (value == null)
+                    {
+                        value = Activator.CreateInstance(typeof(List<>)
+                            .MakeGenericType(prop.PropertyType.GetGenericArguments().First()));
+                        prop.SetValue(converted, value);
+                    }
                     UpdateCollection((IList)value, partConnector.Parts);
                 }
                 else if (partConnector.Parts.Length == 1)
@@ -320,21 +349,25 @@ namespace Moryx.Products.Management.Modification
             var unused = new List<IProductPartLink>(value.OfType<IProductPartLink>());
             // Iterate over the part models
             // Create or update the part links
-            var elemType = value.GetType().GetGenericArguments()[0];
+            var elemType = value.GetType().GetInterfaces()
+                .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IList<>))
+                .Select(i => i.GetGenericArguments()[0]).Single();
             foreach (var partModel in parts)
             {
-                var match = unused.Find(r => r.Id == partModel.Id);
+                if (partModel is null)
+                    continue;
+
+                var match = unused.Find(r => r.Id == partModel?.Id);
                 if (match == null)
                 {
                     match = (IProductPartLink)Activator.CreateInstance(elemType);
                     value.Add(match);
                 }
                 else
-                {
                     unused.Remove(match);
-                }
+
                 EntryConvert.UpdateInstance(match, partModel.Properties);
-                match.Product = (ProductType)ProductManager.LoadType(partModel.Product.Id);
+                match.Product = ProductManager.LoadType(partModel.Product.Id);
             }
 
             // Clear all values no longer present in the model
@@ -345,15 +378,25 @@ namespace Moryx.Products.Management.Modification
         private void UpdateReference(IProductPartLink value, PartModel part)
         {
             EntryConvert.UpdateInstance(value, part.Properties);
-            value.Product = (ProductType)ProductManager.LoadType(part.Product.Id);
+            value.Product = part.Product is null ? null : ProductManager.LoadType(part.Product.Id);
         }
 
         private static void ConvertFilesBack(object converted, ProductModel product, PropertyInfo[] properties)
         {
-            foreach (var fileModel in product.Files)
+            foreach (var fileModel in product.FileModels)
             {
-                var prop = properties.First(p => p.Name == fileModel.Name);
-                prop.SetValue(converted, fileModel);
+                var prop = properties.Single(p => p.Name == fileModel.PropertyName);
+                var productFile = new ProductFile()
+                {
+                    MimeType = fileModel.MimeType,
+                    FilePath = fileModel.FilePath,
+                    FileHash = fileModel.FileHash,
+                    Name = fileModel.FileName
+                };
+                if (productFile.GetType().GetProperties().All(p => p.GetValue(productFile) is null))
+                    prop.SetValue(converted, null);
+                else
+                    prop.SetValue(converted, productFile);
             }
         }
         #endregion

--- a/src/Moryx.Products.Management/Properties/AssemblyInfo.cs
+++ b/src/Moryx.Products.Management/Properties/AssemblyInfo.cs
@@ -2,3 +2,4 @@
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: InternalsVisibleTo("Moryx.Products.IntegrationTests")]
+[assembly: InternalsVisibleTo("Moryx.Products.Management.Tests")]

--- a/src/Moryx.Products.UI/Connected Services/ProductService/Reference.cs
+++ b/src/Moryx.Products.UI/Connected Services/ProductService/Reference.cs
@@ -828,6 +828,8 @@ namespace Moryx.Products.UI.ProductService
     public partial class ProductModel : object
     {
         
+        private Moryx.Products.UI.ProductService.ProductFileModel[] FileModelsField;
+        
         private Moryx.Products.UI.ProductService.ProductFile[] FilesField;
         
         private long IdField;
@@ -847,6 +849,19 @@ namespace Moryx.Products.UI.ProductService
         private Moryx.Products.UI.ProductService.ProductState StateField;
         
         private string TypeField;
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public Moryx.Products.UI.ProductService.ProductFileModel[] FileModels
+        {
+            get
+            {
+                return this.FileModelsField;
+            }
+            set
+            {
+                this.FileModelsField = value;
+            }
+        }
         
         [System.Runtime.Serialization.DataMemberAttribute()]
         public Moryx.Products.UI.ProductService.ProductFile[] Files
@@ -980,7 +995,89 @@ namespace Moryx.Products.UI.ProductService
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.1")]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
+    [System.Runtime.Serialization.DataContractAttribute(Name="ProductFileModel", Namespace="http://schemas.datacontract.org/2004/07/Moryx.Products.Management.Modification")]
+    public partial class ProductFileModel : object
+    {
+        
+        private string FileHashField;
+        
+        private string FileNameField;
+        
+        private string FilePathField;
+        
+        private string MimeTypeField;
+        
+        private string PropertyNameField;
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public string FileHash
+        {
+            get
+            {
+                return this.FileHashField;
+            }
+            set
+            {
+                this.FileHashField = value;
+            }
+        }
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public string FileName
+        {
+            get
+            {
+                return this.FileNameField;
+            }
+            set
+            {
+                this.FileNameField = value;
+            }
+        }
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public string FilePath
+        {
+            get
+            {
+                return this.FilePathField;
+            }
+            set
+            {
+                this.FilePathField = value;
+            }
+        }
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public string MimeType
+        {
+            get
+            {
+                return this.MimeTypeField;
+            }
+            set
+            {
+                this.MimeTypeField = value;
+            }
+        }
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public string PropertyName
+        {
+            get
+            {
+                return this.PropertyNameField;
+            }
+            set
+            {
+                this.PropertyNameField = value;
+            }
+        }
+    }
+    
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
     [System.Runtime.Serialization.DataContractAttribute(Name="ProductFile", Namespace="http://schemas.datacontract.org/2004/07/Moryx.AbstractionLayer.Products")]
     public partial class ProductFile : object
     {

--- a/src/Moryx.Products.UI/IProductServiceModel.cs
+++ b/src/Moryx.Products.UI/IProductServiceModel.cs
@@ -66,6 +66,7 @@ namespace Moryx.Products.UI
         /// <returns>State of the import</returns>
         Task<ImportStateModel> Import(string importerName, Entry parameters);
 
+        // TODO: AL6 Update ServiceReference and change to string
         /// <summary>
         /// Returns the current importer state
         /// </summary>

--- a/src/Tests/Moryx.Products.Management.Tests/Moryx.Products.Management.Tests.csproj
+++ b/src/Tests/Moryx.Products.Management.Tests/Moryx.Products.Management.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net45</TargetFramework>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <DebugType>full</DebugType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="Moryx.Model.InMemory" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
+        <ProjectReference Include="..\..\Moryx.AbstractionLayer.TestTools\Moryx.AbstractionLayer.TestTools.csproj" />
+        <ProjectReference Include="..\..\Moryx.Products.Management\Moryx.Products.Management.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
+++ b/src/Tests/Moryx.Products.Management.Tests/ProductConverterTests.cs
@@ -1,0 +1,261 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moq;
+using Moryx.AbstractionLayer.Identity;
+using Moryx.AbstractionLayer.Products;
+using Moryx.AbstractionLayer.Recipes;
+using Moryx.AbstractionLayer.TestTools;
+using Moryx.Products.Management.Modification;
+using Moryx.Tools;
+using Moryx.Workflows;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Moryx.Products.Management.Tests
+{
+    [TestFixture]
+    public class ProductConverterTests
+    {
+        private Mock<IProductManager> _productManagerMock;
+        private Mock<IRecipeManagement> _recipeManagementMock;
+        private Mock<IWorkplans> _workplanManagementMock;
+
+        private IProductConverter _productConverter;
+
+        [SetUp]
+        public void Setup()
+        {
+            _productManagerMock = new Mock<IProductManager>();
+            _recipeManagementMock = new Mock<IRecipeManagement>();
+            _workplanManagementMock = new Mock<IWorkplans>();
+
+            _productConverter = new ProductConverter()
+            {
+                ProductManager = _productManagerMock.Object,
+                RecipeManagement = _recipeManagementMock.Object,
+                WorkplanManagement = _workplanManagementMock.Object,
+            };
+        }
+
+        #region Products
+        internal static IEnumerable<TestCaseData> ProductForwardBackwardConversionTestCaseGenerator()
+        {
+            // Used only to display tests seperately in TestExplorer
+            var testCaseCounter = 0;
+
+            // Create ProductType objects for test cases
+            var dummyProductTypes = new List<DummyProductType>()
+            {
+                new DummyProductType(),
+                new DummyProductTypeWithParts(),
+                new DummyProductTypeWithParts()
+                {
+                    ProductPartLink = new DummyProductPartLink() { Id=1, Product = new DummyProductType() { Id = 2022 } },
+                    ProductPartLinkEnumerable = new List<DummyProductPartLink>(){ new DummyProductPartLink() { Id=2, Product = new DummyProductType() { Id = 2023 } } }
+                },
+                new DummyProductTypeWithFiles(),
+                new DummyProductTypeWithFiles() { FirstProductFile = new ProductFile() { Name="FirstFile" }, SecondProductFile = new ProductFile() { Name="SecondFile" }}
+            };
+            // Create Recipe objects for test cases
+            var dummyRecipeLists = new List<List<IProductRecipe>>() 
+            { 
+                new List<IProductRecipe>(), 
+                new List<IProductRecipe>() { new ProductRecipe() { Id = 0 } }, 
+                new List<IProductRecipe>() { new ProductRecipe() { Id = 1923 } } 
+            };
+
+            // Create all possible combinations of input settings for the ConvertProduct method
+            foreach (var identity in new IIdentity[] { null, new ProductIdentity("TestIdentifier", 1337) })
+                foreach (ProductState state in Enum.GetValues(typeof(ProductState))) 
+                    foreach (var flat in new bool[] { true, false })
+                        foreach (var dummyType in dummyProductTypes)
+                            foreach (var recipes in dummyRecipeLists)
+                                yield return new TestCaseData(dummyType, state, identity, recipes, flat, testCaseCounter++);
+        }
+        /// <summary>
+        /// Test if the conversion to and back from a ProductModel without modification of the model 
+        /// in between works without information loss.
+        /// </summary>
+        [TestCaseSource(nameof(ProductForwardBackwardConversionTestCaseGenerator))]
+        public void ForwardBackwardProductConversionWithoutInformationLoss(DummyProductType originalProductType, 
+            ProductState state, IIdentity identity, IReadOnlyList<IProductRecipe> recipes, bool flat, int counter)
+        {
+            // Arrange
+            // - Basic ProductType properties
+            originalProductType.Id = 42;
+            originalProductType.Name = "TestName";
+            originalProductType.State = state;
+            originalProductType.Identity = identity;
+            // - Expected behavior from the RecipeManagement
+            if (recipes.Any())
+                ReflectionTool.TestMode = true;
+            _recipeManagementMock.Setup(rm => rm.GetAllByProduct(It.IsAny<IProductType>())).Returns(recipes);
+            _recipeManagementMock.Setup(rm => rm.Get(It.IsAny<long>())).Returns((long id) => new DummyProductRecipe() { Id = id });
+            // - Create target ProductType object
+            var targetDummyProductType = (DummyProductType)Activator.CreateInstance(originalProductType.GetType());
+            targetDummyProductType.Id = 42;
+            // - Expected behavior from the RecipeManagement
+            _productManagerMock.Setup(pm => pm.LoadType(It.IsAny<long>())).Returns((long id) => new DummyProductType() { Id = id });
+            // - Product PartsShould only by included with their id if they already exist
+            var originalProductTypeWithParts = originalProductType as DummyProductTypeWithParts;
+            if (originalProductTypeWithParts is not null && originalProductTypeWithParts.ProductPartLink is not null)
+            {
+                ((DummyProductTypeWithParts)targetDummyProductType).ProductPartLink = ((DummyProductTypeWithParts)originalProductType).ProductPartLink;
+                ((DummyProductTypeWithParts)targetDummyProductType).ProductPartLinkEnumerable = ((DummyProductTypeWithParts)originalProductType).ProductPartLinkEnumerable.Take(1).ToList();
+            }
+
+            // Act
+            var convertedModel = _productConverter.ConvertProduct(originalProductType, flat);
+            var recoveredOriginal = _productConverter.ConvertProductBack(convertedModel, targetDummyProductType);
+
+            // Assert
+            // - Non ProductIdentities will always be transformed into empty ProductIdentities in the Process
+            if (identity is null)
+                originalProductType.Identity = new ProductIdentity("", 0);
+            // - Products originally converted with the flat flag will only affect certain properties
+            if (flat)
+            {
+                Assert.AreEqual(originalProductType.Id, recoveredOriginal.Id);
+                Assert.AreEqual(originalProductType.Name, recoveredOriginal.Name);
+                Assert.AreEqual(originalProductType.State, recoveredOriginal.State);
+                Assert.AreEqual(originalProductType.Identity, recoveredOriginal.Identity);
+                _recipeManagementMock.VerifyNoOtherCalls();
+                _productManagerMock.VerifyNoOtherCalls();
+                return;
+            }
+            // - The following assert uses overwritten Equals methods to check for VALUE equality
+            Assert.AreEqual(originalProductType, recoveredOriginal);
+            // - If there are Recipes the RecipeManagement should be called
+            if (recipes.Any())
+            {
+                _recipeManagementMock.Verify(rm => rm.GetAllByProduct(originalProductType));
+                _recipeManagementMock.Verify(rm => rm.Save(originalProductType.Id, It.Is<List<IProductRecipe>>(list => list.Count == recipes.Count)));
+                if (recipes.First().Id != 0)
+                    _recipeManagementMock.Verify(rm => rm.Get(recipes.First().Id));
+            }                
+            // - If there are ProductPartLinks the ProductManagement should be called
+            var targetDummyTypeWithParts = recoveredOriginal as DummyProductTypeWithParts;
+            if (targetDummyTypeWithParts?.ProductPartLink?.Product is not null)
+            {
+                _productManagerMock.Verify(pm => pm.LoadType(targetDummyTypeWithParts.ProductPartLink.Product.Id));
+                _productManagerMock.Verify(pm => pm.LoadType(targetDummyTypeWithParts.ProductPartLinkEnumerable.First().Product.Id));
+            }
+        }
+        #endregion
+
+        #region Recipes
+        public static IEnumerable<TestCaseData> RecipeForwardBackwardConversionTestCaseGenerator()
+        {
+            // Used only to display tests seperately in TestExplorer
+            var testCaseCounter = 0;
+
+            // Create Recipe objects for test cases
+            var dummyRecipes = new List<DummyProductRecipe>()
+            {
+                new DummyProductRecipe(),
+                new DummyProductWorkplanRecipe() { Workplan = new DummyWorkplan() { Id=2021 } }
+            };
+            // Create all classifications to consider
+            var classifications = Enum.GetValues(typeof(RecipeClassification)).Cast<RecipeClassification>()
+                .Where(c => c != RecipeClassification.Clone && c != RecipeClassification.CloneFilter).ToList();
+            var clonedClassifications = classifications.Select(c => c | RecipeClassification.Clone).ToList();
+            classifications.AddRange(clonedClassifications);
+
+            // Create all possible combinations of input settings for the ConvertRecipe method
+            foreach (var backupProductType in new List<DummyProductType>() { null, new DummyProductType()})
+                foreach (RecipeState state in Enum.GetValues(typeof(RecipeState)))
+                    foreach (var classification in classifications)
+                        foreach (var dummyRecipe in dummyRecipes)
+                        {
+                            //dummyRecipe.Classification = classification;
+                            //dummyRecipe.State = state;
+                            var workplanInTargetRecipe = (dummyRecipe as DummyProductWorkplanRecipe)?.Workplan;
+                            if (workplanInTargetRecipe is not null)
+                                yield return new TestCaseData(dummyRecipe, classification, state, backupProductType, new DummyWorkplan() { Id = 1 }, testCaseCounter++);
+                            yield return new TestCaseData(dummyRecipe, classification, state, backupProductType, workplanInTargetRecipe, testCaseCounter++);
+                        }
+        }
+
+        //Problem Entry Convert
+        [TestCaseSource(nameof(RecipeForwardBackwardConversionTestCaseGenerator))]
+        public void ForwardBackwardRecipeConversionWithoutInformationLoss(DummyProductRecipe originalRecipe, RecipeClassification classification, RecipeState state, 
+            DummyProductType backupProductType, DummyWorkplan workplanInTargetRecipe, int testCaseCounter)
+        {
+            // Arrange
+            // - Basic Workplan properties
+            originalRecipe.Id = 42;
+            originalRecipe.Name = "TestName";
+            originalRecipe.Revision = 1337;
+            originalRecipe.Classification = classification;
+            originalRecipe.State = state;
+            // - Mock workplan requests if there could be a Workplan
+            var originalWorkplanRecipe = originalRecipe as DummyProductWorkplanRecipe;
+            if (originalWorkplanRecipe is not null)
+            {
+                _workplanManagementMock.Setup(wm => wm.LoadWorkplan(It.IsAny<long>()))
+                    .Returns((long id) => new DummyWorkplan() { Id = id });
+            }
+            // - Create target object
+            var targetDummyRecipe = (DummyProductRecipe)Activator.CreateInstance(originalRecipe.GetType());
+            targetDummyRecipe.Id = 42;
+            if (originalWorkplanRecipe is not null)
+                ((DummyProductWorkplanRecipe)targetDummyRecipe).Workplan = workplanInTargetRecipe;
+            // - No change of classification on clones should be possible, thereby preset it 
+            if (originalRecipe.Classification.HasFlag(RecipeClassification.Clone))
+                targetDummyRecipe.Classification = originalRecipe.Classification;
+
+
+            // Act
+            var convertedModel = _productConverter.ConvertRecipe(originalRecipe);
+            var recoveredOriginal = _productConverter.ConvertRecipeBack(convertedModel, targetDummyRecipe, backupProductType);
+
+
+            // Assert
+            // - Backup products are used for recipes without products
+            if (originalRecipe.Product is null)
+                originalRecipe.Product = backupProductType;
+            
+            Assert.AreEqual(originalRecipe, recoveredOriginal);
+            // - If there is a workplan and it changed, reload it at backward conversion
+            if (originalWorkplanRecipe?.Workplan is not null && originalWorkplanRecipe.Workplan.Id != workplanInTargetRecipe.Id)
+                _workplanManagementMock.Verify(wm => wm.LoadWorkplan(originalWorkplanRecipe.Workplan.Id), Times.Once);
+            else
+                _workplanManagementMock.VerifyNoOtherCalls();
+        }
+        #endregion
+
+        #region Workplans
+        public static IEnumerable<TestCaseData> WorkplanForwardConversionTestCaseGenerator()
+        {
+            foreach (var wpState in Enum.GetValues(typeof(WorkplanState)))
+                yield return new TestCaseData(wpState);
+        }
+
+        //Problem Entry Convert
+        [TestCaseSource(nameof(WorkplanForwardConversionTestCaseGenerator))]
+        public void ForwardWorkplanConversionWithoutInformationLoss(WorkplanState wpState)
+        {
+            // Arrange
+            var originalWorkplan = new DummyWorkplan()
+            {
+                Id=42,
+                Name="TestWorkplan",
+                Version=1,
+                State=wpState
+            };
+
+            // Act
+            var convertedmodel = _productConverter.ConvertWorkplan(originalWorkplan);
+
+            // Assert
+            Assert.AreEqual(originalWorkplan.Id, convertedmodel.Id);
+            Assert.AreEqual(originalWorkplan.Name, convertedmodel.Name);
+            Assert.AreEqual(originalWorkplan.Version,convertedmodel.Version);
+            Assert.AreEqual(originalWorkplan.State,convertedmodel.State);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Adds unit tests for the ProductConverter class.

In addition some yet unreported errors are fixed:
- The converter can now process ProductFile properties even if the filename and the propertyname are not identical
- Possible NullReferenceExceptions when comparing Products with empty identity properties are prevented now
- Fixed NullReferenceExeptions when dealing with empty properties of type IList<IProductPartLink>
- Converter does not call the RecipeManagement if now recipes are to be safed
- Converter can now handle removed ProductPartLinks in the backwards conversion
- Converter can handle ProductPartLinks with empty product properties


