### PR TITLE
Add Workplan Model to Recipe Model

### DIFF
--- a/src/Moryx.Products.Management/Modification/Model/RecipeModel.cs
+++ b/src/Moryx.Products.Management/Modification/Model/RecipeModel.cs
@@ -52,10 +52,17 @@ namespace Moryx.Products.Management.Modification
         public Entry Properties { get; set; }
 
         /// <summary>
-        /// The id of the current referenced workplan
+        /// The id of the currently referenced workplan
         /// </summary>
+        [Obsolete]
         [DataMember]
         public long WorkplanId { get; set; }
+
+        /// <summary>
+        /// A model of the currently referenced workplan
+        /// </summary>
+        [DataMember]
+        public WorkplanModel WorkplanModel { get; set; }
 
         /// <summary>
         /// Classification of the recipe

--- a/src/Moryx.Products.Management/Modification/ProductConverter.cs
+++ b/src/Moryx.Products.Management/Modification/ProductConverter.cs
@@ -204,7 +204,11 @@ namespace Moryx.Products.Management.Modification
 
             var wpRecipe = recipe as IWorkplanRecipe;
             if (wpRecipe?.Workplan != null)
+            {
                 converted.WorkplanId = wpRecipe.Workplan.Id;
+                converted.WorkplanModel = ConvertWorkplan(wpRecipe.Workplan);
+            }
+                
 
             return converted;
         }

--- a/src/Moryx.Products.UI.Interaction/Recipes/Details/RecipeDetailsViewModelBase.cs
+++ b/src/Moryx.Products.UI.Interaction/Recipes/Details/RecipeDetailsViewModelBase.cs
@@ -63,7 +63,7 @@ namespace Moryx.Products.UI.Interaction
 
             WorkplanViewModel wp = null;
             if (recipeModel.WorkplanId != 0)
-                wp = workplans.FirstOrDefault(w => w.Id == recipeModel.WorkplanId);
+                wp = Workplans.FirstOrDefault(w => w.Id == recipeModel.WorkplanId);
 
             EditableObject = new RecipeViewModel(recipeModel)
             {
@@ -81,8 +81,8 @@ namespace Moryx.Products.UI.Interaction
             await LoadTypeAndWorkplans(recipeVm.Model, workplans);
 
             WorkplanViewModel wp = null;
-            if (recipeVm.Model.WorkplanId != 0)
-                wp = workplans.FirstOrDefault(w => w.Id == recipeVm.Model.WorkplanId);
+            if ((recipeVm.Model.WorkplanModel?.Id ?? recipeVm.Model.WorkplanId) != 0)
+                wp = Workplans.FirstOrDefault(w => w.Id == (recipeVm.Model.WorkplanModel?.Id ?? recipeVm.Model.WorkplanId));
             recipeVm.Workplan = wp;
 
             EditableObject = recipeVm;
@@ -90,7 +90,10 @@ namespace Moryx.Products.UI.Interaction
 
         private async Task LoadTypeAndWorkplans(RecipeModel model, IReadOnlyCollection<WorkplanViewModel> workplans)
         {
-            Workplans = workplans;
+            if (!workplans.Any(w => w.Id == (model.WorkplanModel?.Id ?? model.WorkplanId)) && model.WorkplanModel is not null)
+                Workplans = workplans.Concat(new WorkplanViewModel[] { new WorkplanViewModel(model.WorkplanModel) }).ToList();
+            else
+                Workplans = workplans;
             NotifyOfPropertyChange(nameof(Workplans));
 
             var customization = await ProductServiceModel.GetCustomization();

--- a/src/Moryx.Products.UI/Connected Services/ProductService/Reference.cs
+++ b/src/Moryx.Products.UI/Connected Services/ProductService/Reference.cs
@@ -1264,6 +1264,8 @@ namespace Moryx.Products.UI.ProductService
         
         private long WorkplanIdField;
         
+        private Moryx.Products.UI.ProductService.WorkplanModel WorkplanModelField;
+        
         [System.Runtime.Serialization.DataMemberAttribute()]
         public Moryx.Products.UI.ProductService.RecipeClassificationModel Classification
         {
@@ -1380,6 +1382,19 @@ namespace Moryx.Products.UI.ProductService
                 this.WorkplanIdField = value;
             }
         }
+        
+        [System.Runtime.Serialization.DataMemberAttribute()]
+        public Moryx.Products.UI.ProductService.WorkplanModel WorkplanModel
+        {
+            get
+            {
+                return this.WorkplanModelField;
+            }
+            set
+            {
+                this.WorkplanModelField = value;
+            }
+        }
     }
     
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.1")]
@@ -1448,8 +1463,8 @@ namespace Moryx.Products.UI.ProductService
             }
         }
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.1")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
     [System.Runtime.Serialization.DataContractAttribute(Name="RecipeClassificationModel", Namespace="http://schemas.datacontract.org/2004/07/Moryx.Products.Management.Modification")]
     public enum RecipeClassificationModel : int
     {
@@ -1469,8 +1484,8 @@ namespace Moryx.Products.UI.ProductService
         [System.Runtime.Serialization.EnumMemberAttribute()]
         Part = 4,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.1")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
     [System.Runtime.Serialization.DataContractAttribute(Name="RecipeState", Namespace="http://schemas.datacontract.org/2004/07/Moryx.AbstractionLayer.Recipes")]
     public enum RecipeState : int
     {
@@ -1670,8 +1685,8 @@ namespace Moryx.Products.UI.ProductService
         [System.Runtime.Serialization.EnumMemberAttribute()]
         Revoked = 2,
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.1")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
     [System.ServiceModel.ServiceContractAttribute(ConfigurationName="Moryx.Products.UI.ProductService.IProductInteraction")]
     public interface IProductInteraction
     {
@@ -1727,8 +1742,8 @@ namespace Moryx.Products.UI.ProductService
         [System.ServiceModel.OperationContractAttribute(Action="http://tempuri.org/IProductInteraction/GetRecipeProviderName", ReplyAction="http://tempuri.org/IProductInteraction/GetRecipeProviderNameResponse")]
         System.Threading.Tasks.Task<string> GetRecipeProviderNameAsync();
     }
-    
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.1")]
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.0.2")]
     public interface IProductInteractionChannel : Moryx.Products.UI.ProductService.IProductInteraction, System.ServiceModel.IClientChannel
     {
     }


### PR DESCRIPTION
Fixes bug in the RecipeView mentioned in #134. The DropDown menu now contains all available workplans and the currently selected one for a recipe even if a newer version of the Workplan already exists. 