### PR TITLE
Replace Activity<T> with IActivity<T> in WorkplanExtension

### DIFF
--- a/src/Moryx.AbstractionLayer/Workplan/WorkplanExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Workplan/WorkplanExtensions.cs
@@ -79,7 +79,7 @@ namespace Moryx.AbstractionLayer
         /// <param name="outputs">The outputs of the steps.</param>
         /// <returns></returns>
         public static TaskStep<TActivity, TParam> AddStep<TActivity, TParam>(this Workplan workplan, TaskStep<TActivity, TParam> task, TParam parameter, IConnector[] input, params IConnector[] outputs)
-            where TActivity : Activity<TParam>, new()
+            where TActivity : IActivity<TParam>, new()
             where TParam : IParameters, new()
         {
             task.Parameters = parameter;
@@ -108,7 +108,7 @@ namespace Moryx.AbstractionLayer
         /// <param name="outputs">The outputs of the steps.</param>
         /// <returns></returns>
         public static TaskStep<TActivity, TProcParam, TParam> AddStep<TActivity, TProcParam, TParam>(this Workplan workplan, TaskStep<TActivity, TProcParam, TParam> task, TParam parameter, IConnector[] input, params IConnector[] outputs)
-            where TActivity : Activity<TProcParam>, new()
+            where TActivity : IActivity<TProcParam>, new()
             where TProcParam : IParameters
             where TParam : TProcParam, new()
         {


### PR DESCRIPTION
The two respective methods are unnecessarily restrictive and should follow the same pattern of conditions as the other two extension methods.