### PR TITLE
Bugfixing of a Error where ResourceFacade throws Exceptions due to missing else statement

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/ResourceFacadeExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Resources/ResourceFacadeExtensions.cs
@@ -42,8 +42,8 @@ namespace Moryx.AbstractionLayer.Resources
         {
             if (facade is IResourceModification modification)
                 modification.Modify(resourceId, modifier);
-
-            throw new NotSupportedException("Instance of resource management does not support resource modification");
+            else
+                throw new NotSupportedException("Instance of resource management does not support resource modification");
         }
 
         /// <summary>
@@ -56,8 +56,8 @@ namespace Moryx.AbstractionLayer.Resources
         {
             if (facade is IResourceModification modification)
                 modification.Modify(proxy.Id, modifier);
-
-            throw new NotSupportedException("Instance of resource management does not support resource modification");
+            else
+                throw new NotSupportedException("Instance of resource management does not support resource modification");
         }
 
         /// <summary>
@@ -71,8 +71,8 @@ namespace Moryx.AbstractionLayer.Resources
         {
             if (facade is IResourceModification modification)
                 modification.Modify(proxy.Id, resource => modifier(resource, context));
-
-            throw new NotSupportedException("Instance of resource management does not support resource modification");
+            else
+                throw new NotSupportedException("Instance of resource management does not support resource modification");
         }
     }
 }


### PR DESCRIPTION

### Summary

The Bugs occurs when trying to modify the ResourceFacade. It happens due to a missing else statement. Thus Exceptions are also thrown if the Modification has been made. Added a else statement to avoid this behaviour.

### Relevant logs and/or screenshots


### Review

<!-- 
The bullet points will be edited by the reviewer 
-->

**Typical tasks**

- [ ] Merge-Request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets

/label ~Bug