### PR TITLE
Extend NotificationPublisher API

### DIFF
--- a/src/Moryx.Notifications/INotificationPublisher.cs
+++ b/src/Moryx.Notifications/INotificationPublisher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using System;
@@ -8,6 +8,7 @@ namespace Moryx.Notifications
     /// <summary>
     /// Notification publisher facade
     /// </summary>
+    [Obsolete]
     public interface INotificationPublisher
     {
         /// <summary>

--- a/src/Moryx.Notifications/INotificationPublisherExtended.cs
+++ b/src/Moryx.Notifications/INotificationPublisherExtended.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+
+namespace Moryx.Notifications
+{
+    /// <summary>
+    /// Notification publisher facade
+    /// </summary>
+    public interface INotificationPublisherExtended
+    {
+        /// <summary>
+        /// Returns all active notifications
+        /// </summary>
+        Notification[] GetAll();
+
+        /// <summary>
+        /// Gets a <see cref="Notification"/> corresponding to a specific <paramref name="id"/>
+        /// If this is an inactive <see cref="Notification"/>, than the NotificationHistory will be used to search for the asked <see cref="Notification"/>
+        /// </summary>
+        /// <param name="id">Id of the desired <see cref="Notification"/></param>
+        /// <returns>A <see cref="Notification"/> correspodning to the given id if it exists; null otherwise</returns>
+        Notification Get(Guid id);
+
+        /// <summary>
+        /// Acknowledge the given Notificatione
+        /// </summary>
+        /// <param name="notification">The notification to be acknowledged</param>
+        void Acknowledge(Notification notification);
+
+        /// <summary>
+        /// Raised if notification was published
+        /// </summary>
+        event EventHandler<Notification> Published;
+
+        /// <summary>
+        /// Raised if notification was acknowledged
+        /// </summary>
+        event EventHandler<Notification> Acknowledged;
+    }
+}

--- a/src/Moryx.Notifications/Notification/INotification.cs
+++ b/src/Moryx.Notifications/Notification/INotification.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using System;
@@ -8,6 +8,7 @@ namespace Moryx.Notifications
     /// <summary>
     /// Additional notification interface to manipulate the notification properties in managing plugins
     /// </summary>
+    [Obsolete]
     public interface IManagedNotification : INotification
     {
         /// <summary>
@@ -72,6 +73,7 @@ namespace Moryx.Notifications
     /// <summary>
     /// Message for a consumer
     /// </summary>
+    [Obsolete]
     public interface INotification
     {
         /// <summary>

--- a/src/Moryx.Notifications/Notification/Notification.cs
+++ b/src/Moryx.Notifications/Notification/Notification.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using System;
@@ -14,35 +14,114 @@ namespace Moryx.Notifications
         public Guid Identifier { get; private set; }
 
         /// <inheritdoc />
+        public Severity Severity { get; set; }
+
+        /// <inheritdoc />
+        public string Title { get; set; }
+
+        /// <inheritdoc />
+        public string Message { get; set; }
+        
+        /// <inheritdoc />
+        public string Sender { get; set; }
+
+        /// <inheritdoc />
+        public string Source { get; set; }
+
+        /// <inheritdoc />
+        public bool IsAcknowledgable { get; set; }
+
+        // TODO: AL6 remove explicit backing attribute for property
+        private DateTime? _acknowledged;
+        /// <inheritdoc />
+        public virtual DateTime? Acknowledged 
+        { 
+            get => _acknowledged; 
+            set 
+            {
+                if (_acknowledged is null)
+                    _acknowledged = value;
+                else
+                    throw new InvalidOperationException("Tried to update time of acknowledgement.");
+            } 
+        }
+
+        // TODO: AL6 remove explicit backing attribute for property
+        private string _acknowledger;
+        /// <inheritdoc />
+        public virtual string Acknowledger
+        {
+            get => _acknowledger;
+            set
+            {
+                if (_acknowledger is null)
+                    _acknowledger = value;
+                else
+                    throw new InvalidOperationException("Tried to update time acknowledger.");
+            }
+        }
+
+        // TODO: AL6 Remove backing attribute for property and make property nullable
+        private DateTime? _created;
+        /// <inheritdoc />
+        public virtual DateTime Created
+        {
+            get => _created ?? default(DateTime);
+            set
+            {
+                if (_created is null)
+                    _created = value;
+                else
+                    throw new InvalidOperationException("Tried to update creation time.");
+            }
+        }
+
+        /// <summary>
+        /// Creates a new notification
+        /// </summary>
+        public Notification()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new notification with title and message
+        /// </summary>
+        [Obsolete]
+        public Notification(string title, string message, Severity severity) : this()
+        {
+            Title = title;
+            Message = message;
+            Severity = severity;
+        }
+
+        /// <summary>
+        /// Creates a new notification with title and message
+        /// </summary>
+        [Obsolete]
+        public Notification(string title, string message, Severity severity, bool isAcknowledgable) : this(title, message, severity)
+        {
+            IsAcknowledgable = isAcknowledgable;
+        }
+
+        #region IManagedNotification
+        /// <inheritdoc />
         Guid IManagedNotification.Identifier
         {
             get => Identifier;
             set => Identifier = value;
         }
 
-        /// <inheritdoc />
-        public DateTime? Acknowledged { get; private set; }
-
         DateTime? IManagedNotification.Acknowledged
         {
-            get => Acknowledged;
-            set => Acknowledged = value;
+            get => _acknowledged;
+            set => _acknowledged = value;
         }
-
-        /// <inheritdoc cref="IManagedNotification.IsAcknowledgable" />
-        public bool IsAcknowledgable { get; set; }
-
-        /// <inheritdoc />
-        public string Acknowledger { get; private set; }
 
         string IManagedNotification.Acknowledger
         {
             get => Acknowledger;
             set => Acknowledger = value;
         }
-
-        /// <inheritdoc />
-        public DateTime Created { get; private set; }
 
         DateTime IManagedNotification.Created
         {
@@ -55,39 +134,6 @@ namespace Moryx.Notifications
 
         /// <inheritdoc />
         string IManagedNotification.Source { get; set; }
-
-        /// <inheritdoc />
-        public Severity Severity { get; set; }
-
-        /// <inheritdoc />
-        public string Title { get; set; }
-
-        /// <inheritdoc />
-        public string Message { get; set; }
-
-        /// <summary>
-        /// Creates a new notification
-        /// </summary>
-        public Notification()
-        {
-        }
-
-        /// <summary>
-        /// Creates a new notification with title and message
-        /// </summary>
-        public Notification(string title, string message, Severity severity) : this()
-        {
-            Title = title;
-            Message = message;
-            Severity = severity;
-        }
-
-        /// <summary>
-        /// Creates a new notification with title and message
-        /// </summary>
-        public Notification(string title, string message, Severity severity, bool isAcknowledgable) : this(title, message, severity)
-        {
-            IsAcknowledgable = isAcknowledgable;
-        }
+        #endregion
     }
 }


### PR DESCRIPTION
Adds the INotificationManager interface providing an extended API for the NotificationPublisher Facade. The changes also respect  #139 as the new API relies on the Notification class directly.

To prevent the user from accidently corrupting the Notification, while not making it immutable to guarantee that a single instance represents a notification throughout the process, the relevant properties are designed to be setable only once.

The backing fields in Notification are required to ensure backward compatibility and will be removed for the next major.