### PR TITLE
Fixed wrong handling of the product type tree while finding a type

### DIFF
--- a/src/Moryx.Products.UI.Interaction/Products/ProductsWorkspaceViewModel.cs
+++ b/src/Moryx.Products.UI.Interaction/Products/ProductsWorkspaceViewModel.cs
@@ -411,7 +411,8 @@ namespace Moryx.Products.UI.Interaction
             IsBusy = true;
 
             // Get group
-            var group = ProductGroups.Single(t => t.TypeName == dialog.CreatedProduct.Type);
+            var flatProductGroups = ProductGroups.Flatten(g => g.Children.OfType<TypeItemViewModel>());
+            var group = flatProductGroups.Single(t => t.TypeName == dialog.CreatedProduct.Type);
 
             // Create new tree item
             var newItem = new ProductItemViewModel(createdProduct.Model);
@@ -448,7 +449,8 @@ namespace Moryx.Products.UI.Interaction
             IsBusy = true;
 
             // Get group
-            var group = ProductGroups.Single(t => t.TypeName == dialog.ClonedProduct.Type);
+            var flatProductGroups = ProductGroups.Flatten(g => g.Children.OfType<TypeItemViewModel>());
+            var group = flatProductGroups.Single(t => t.TypeName == dialog.ClonedProduct.Type);
 
             // Create new tree item
             var newItem = new ProductItemViewModel(dialog.ClonedProduct);


### PR DESCRIPTION
There will be an exception if the product UI is configured to show a product tree instead of a list and you try to duplicate or create a new revision of a product.
In this case only the root nodes are scanned for the corresponding type which will be not found.
The solution is simple. Just flatten the tree to find the type.