### PR TITLE
Add method to resourceManagement facade in order to get all resources

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/IResourceModificationExtended.cs
+++ b/src/Moryx.AbstractionLayer/Resources/IResourceModificationExtended.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 
 namespace Moryx.AbstractionLayer.Resources
 {
+    /// <summary>
+    /// Facade for returning all resources and not only resources implementing IPublicResource
+    /// </summary>
+    // TODO: Move into IResourceManagement
     public interface IResourceModificationExtended: IResourceModification
     {
         /// <summary>

--- a/src/Moryx.AbstractionLayer/Resources/IResourceModificationExtended.cs
+++ b/src/Moryx.AbstractionLayer/Resources/IResourceModificationExtended.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Moryx.AbstractionLayer.Resources
+{
+    public interface IResourceModificationExtended: IResourceModification
+    {
+        /// <summary>
+        /// Get all resources inluding the private ones of this type that match the predicate
+        /// </summary>
+        IEnumerable<TResource> GetAllResources<TResource>(Func<TResource, bool> predicate)
+            where TResource : class, IResource;
+    }
+}

--- a/src/Moryx.Resources.Management.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.Resources.Management.Endpoints/ResourceManagementController.cs
@@ -22,11 +22,11 @@ namespace Moryx.Resources.Management.Endpoints
     [Produces("application/json")]
     public class ResourceModificationController : ControllerBase
     {
-        private readonly IResourceModification _resourceModification;
+        private readonly IResourceModificationExtended _resourceModification;
         private readonly IResourceTypeTree _resourceTypeTree;
         private readonly ResourceSerialization _serialization;
 
-        public ResourceModificationController(IResourceModification resourceModification)
+        public ResourceModificationController(IResourceModificationExtended resourceModification)
         {
             _resourceModification = resourceModification ?? throw new ArgumentNullException(nameof(resourceModification));
             _resourceTypeTree = _resourceModification as IResourceTypeTree ?? throw new InvalidCastException(nameof(resourceModification));
@@ -64,10 +64,11 @@ namespace Moryx.Resources.Management.Endpoints
         public ActionResult<ResourceModel[]> GetResources(ResourceQuery query)
         {
             var filter = new ResourceQueryFilter(query, _resourceTypeTree);
-            var resourceProxies = _resourceModification.GetResources<IPublicResource>(r => filter.Match(r as Resource)).ToArray();
+            var resourceProxies = _resourceModification.GetAllResources<IResource>(r => filter.Match(r as Resource)).ToArray();
 
             var converter = new ResourceQueryConverter(_resourceTypeTree, _serialization, query);
-            return resourceProxies.Select(p => _resourceModification.Read(p.Id, r => converter.QueryConversion(r))).ToArray();
+            var values = resourceProxies.Select(p => _resourceModification.Read(p.Id, r => converter.QueryConversion(r))).ToArray();
+            return values;
         }
 
         [HttpGet]

--- a/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
@@ -10,7 +10,7 @@ using Moryx.Runtime.Modules;
 namespace Moryx.Resources.Management
 {
     // TODO: AL6 combine IResourceManagement with IResourceModification and make second facade for IResourceTypeTree
-    internal class ResourceManagementFacade : IResourceManagement, IFacadeControl, IResourceModification, IResourceTypeTree
+    internal class ResourceManagementFacade : IResourceManagement, IFacadeControl, IResourceModificationExtended, IResourceTypeTree
     {
         #region Dependency Injection
 
@@ -114,6 +114,8 @@ namespace Moryx.Resources.Management
             ValidateHealthState();
             return ResourceGraph.GetResources(predicate).Proxify(TypeController);
         }
+
+
         #endregion
 
         #region IResourceModification
@@ -162,6 +164,13 @@ namespace Moryx.Resources.Management
 
             return ResourceGraph.Destroy(resource);
         }
+
+        public IEnumerable<TResource> GetAllResources<TResource>(Func<TResource, bool> predicate)
+             where TResource : class, IResource
+        {
+            ValidateHealthState();
+            return ResourceGraph.GetResources(predicate);
+        }
         #endregion
 
         #region IResourceTypeTree
@@ -178,6 +187,8 @@ namespace Moryx.Resources.Management
         {
             return TypeTree.SupportedTypes(constraints);
         }
+
+        
         #endregion
 
         /// <inheritdoc />

--- a/src/StartProject.Asp/StartProject.Asp.csproj
+++ b/src/StartProject.Asp/StartProject.Asp.csproj
@@ -21,6 +21,7 @@
 	  <ProjectReference Include="..\Moryx.Products.Management\Moryx.Products.Management.csproj" />
 	  <ProjectReference Include="..\Moryx.Resources.Management.Endpoints\Moryx.Resources.Management.Endpoints.csproj" />
 	  <ProjectReference Include="..\Moryx.Resources.Management\Moryx.Resources.Management.csproj" />
+	  <ProjectReference Include="..\Moryx.Resources.Samples\Moryx.Resources.Samples.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/StartProject.Asp/Startup.cs
+++ b/src/StartProject.Asp/Startup.cs
@@ -1,10 +1,12 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moryx;
 using Moryx.AbstractionLayer.Products.Endpoints;
 using Moryx.Asp.Integration;
+using System.Text.Json.Serialization;
 
 namespace StartProject.Asp
 {
@@ -36,8 +38,13 @@ namespace StartProject.Asp
             services.AddSignalR();
             // Add MORYX SignalR hubs
             services.AddMoryxProductManagementHub();
-            services.AddControllers();
-            services.AddSwaggerGen();
+            services.AddControllers()
+               .AddJsonOptions(jo => jo.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+
+            services.AddSwaggerGen(c =>
+            {
+                c.CustomOperationIds(api => ((ControllerActionDescriptor)api.ActionDescriptor).MethodInfo.Name);
+            });
         }
 
         // Configure() is used to specify how the app responds to HTTP requests. The request pipeline is configured


### PR DESCRIPTION
In the current version the resourceManagement facade can only return resources which implement IPublicResource. This doesn't work anymore when using an endpoint which is hosted outside of the module