### PR TITLE
Ignore read only properties in product storage and source cleanup

### DIFF
--- a/AbstractionLayer.sln
+++ b/AbstractionLayer.sln
@@ -47,11 +47,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Resources.Wcf", "src\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Products.Management.Tests", "src\Tests\Moryx.Products.Management.Tests\Moryx.Products.Management.Tests.csproj", "{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.Resources.Management.Endpoints", "src\Moryx.Resources.Management.Endpoints\Moryx.Resources.Management.Endpoints.csproj", "{A39CC935-5A9C-424B-BCD6-6957E3D210B4}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.AbstractionLayer.Products.Endpoints", "src\Moryx.AbstractionLayer.Products.Endpoints\Moryx.AbstractionLayer.Products.Endpoints.csproj", "{230A5D64-C34E-49E0-B5FA-4062AF227211}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StartProject.Asp", "src\StartProject.Asp\StartProject.Asp.csproj", "{48E5CBD4-D7B3-410B-9CDD-A1E355133E3A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moryx.AbstractionLayer.Resources.Endpoints", "src\Moryx.AbstractionLayer.Resources.Endpoints\Moryx.AbstractionLayer.Resources.Endpoints.csproj", "{F5141A5C-D29F-4870-85D5-277C04A944EC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -123,10 +123,6 @@ Global
 		{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A39CC935-5A9C-424B-BCD6-6957E3D210B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A39CC935-5A9C-424B-BCD6-6957E3D210B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A39CC935-5A9C-424B-BCD6-6957E3D210B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A39CC935-5A9C-424B-BCD6-6957E3D210B4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{230A5D64-C34E-49E0-B5FA-4062AF227211}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{230A5D64-C34E-49E0-B5FA-4062AF227211}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{230A5D64-C34E-49E0-B5FA-4062AF227211}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -135,6 +131,10 @@ Global
 		{48E5CBD4-D7B3-410B-9CDD-A1E355133E3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48E5CBD4-D7B3-410B-9CDD-A1E355133E3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48E5CBD4-D7B3-410B-9CDD-A1E355133E3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5141A5C-D29F-4870-85D5-277C04A944EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5141A5C-D29F-4870-85D5-277C04A944EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5141A5C-D29F-4870-85D5-277C04A944EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5141A5C-D29F-4870-85D5-277C04A944EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -155,8 +155,8 @@ Global
 		{583CBD84-DD9F-4834-A89C-1625A05EE15D} = {BA183EBF-FAC1-45AE-9559-09879DB103AC}
 		{E1AD28CD-37A6-4AF6-80D7-756586A727B6} = {BA183EBF-FAC1-45AE-9559-09879DB103AC}
 		{0CCA2AFB-1788-44C2-8919-F5CD46BC94AD} = {D6D69517-7889-4E08-ABEA-D3E069D08A6B}
-		{A39CC935-5A9C-424B-BCD6-6957E3D210B4} = {BA183EBF-FAC1-45AE-9559-09879DB103AC}
 		{230A5D64-C34E-49E0-B5FA-4062AF227211} = {FE34A376-8F97-4D98-8C84-44A0C1AC01E0}
+		{F5141A5C-D29F-4870-85D5-277C04A944EC} = {BA183EBF-FAC1-45AE-9559-09879DB103AC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {23463631-1BA0-41B8-ABA3-1E9741037513}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ If you want to start developing with or for MORYX, the easiest way is our [templ
 |--------------|-----------------|------------|
 | `Moryx.AbstractionLayer` | [![NuGet](https://img.shields.io/nuget/v/Moryx.AbstractionLayer.svg)](https://www.nuget.org/packages/Moryx.AbstractionLayer/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.AbstractionLayer)](https://www.myget.org/feed/moryx/package/nuget/Moryx.AbstractionLayer) |
 | `Moryx.AbstractionLayer.TestTools` | [![NuGet](https://img.shields.io/nuget/v/Moryx.AbstractionLayer.TestTools.svg)](https://www.nuget.org/packages/Moryx.AbstractionLayer.TestTools/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.AbstractionLayer.TestTools)](https://www.myget.org/feed/moryx/package/nuget/Moryx.AbstractionLayer.TestTools) |
+| `Moryx.AbstractionLayer.Products.Endpoints` | [![NuGet](https://img.shields.io/nuget/v/Moryx.AbstractionLayer.Products.Endpoints.svg)](https://www.nuget.org/packages/Moryx.AbstractionLayer.Products.Endpoints/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.AbstractionLayer.Products.Endpoints)](https://www.myget.org/feed/moryx/package/nuget/Moryx.AbstractionLayer.Products.Endpoints) |
+| `Moryx.AbstractionLayer.Resources.Endpoints` | [![NuGet](https://img.shields.io/nuget/v/Moryx.AbstractionLayer.Resources.Endpoints.svg)](https://www.nuget.org/packages/Moryx.AbstractionLayer.Resources.Endpoints/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.AbstractionLayer.Resources.Endpoints)](https://www.myget.org/feed/moryx/package/nuget/Moryx.AbstractionLayer.Resources.Endpoints) |
 | `Moryx.Notifications` | [![NuGet](https://img.shields.io/nuget/v/Moryx.Notifications.svg)](https://www.nuget.org/packages/Moryx.Notifications/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.Notifications)](https://www.myget.org/feed/moryx/package/nuget/Moryx.Notifications) |
 | `Moryx.Products.Management` | [![NuGet](https://img.shields.io/nuget/v/Moryx.Products.Management.svg)](https://www.nuget.org/packages/Moryx.Products.Management/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.Products.Management)](https://www.myget.org/feed/moryx/package/nuget/Moryx.Products.Management) |
 | `Moryx.Products.Model` | [![NuGet](https://img.shields.io/nuget/v/Moryx.Products.Model.svg)](https://www.nuget.org/packages/Moryx.Products.Model/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.Products.Model)](https://www.myget.org/feed/moryx/package/nuget/Moryx.Products.Model) |
@@ -53,7 +55,7 @@ Whether you want to debug and experiment with this repository or build an applic
 1. Create or configure the database for *Moryx.Products.Model* using the Maintenance
 2. Configure the [storage mapping](/docs/articles/Products/ProductStorage.md) for your domain objects. This is necessary to store, load and use the objects within MORYX.
 
-**Resource Management**: 
+**Resource Management**:
 1. Create or configure the database for *Moryx.Resources.Model*
 2. Execute the `ResourceInteractionInitializer` from [ResourceManager console](http://localhost/maintenanceweb/#/modules/ResourceManager/console) to provide the endpoint for the resource configuration UI.
 

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductInstanceModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductInstanceModel.cs
@@ -1,4 +1,7 @@
-﻿using Moryx.Serialization;
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.Serialization;
 using System.Runtime.Serialization;
 
 namespace Moryx.AbstractionLayer.Products.Endpoints.Model
@@ -15,10 +18,10 @@ namespace Moryx.AbstractionLayer.Products.Endpoints.Model
         [DataMember]
         public string Type { get; set; }
 
-        [DataMember]
         /// <summary>
         /// The current state of the instance
         /// </summary>
+        [DataMember]
         public ProductInstanceState State { get; set; }
 
         [DataMember]

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Moryx.AbstractionLayer.Products.Endpoints.csproj
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Moryx.AbstractionLayer.Products.Endpoints.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-	  <Description>Endpoints for the Product Facade</Description>
-	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	  <CreatePackage>true</CreatePackage>
-	  <PackageTags>MORYX;IIoT;IoT;</PackageTags>
+      <Description>Endpoints for the Product Facade</Description>
+      <GenerateDocumentationFile>true</GenerateDocumentationFile>
+      <CreatePackage>true</CreatePackage>
+      <PackageTags>MORYX;IIoT;IoT;</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,11 +24,11 @@
   </ItemGroup>
 
   <ItemGroup>
-	<FrameworkReference Include="Microsoft.AspNetCore.App" Version="5.0.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
+    <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Moryx.AbstractionLayer.Products.Endpoints.csproj
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Moryx.AbstractionLayer.Products.Endpoints.csproj
@@ -22,16 +22,13 @@
     <Compile Include="..\Moryx.Products.Management\Modification\Model\WorkplanModel.cs" Link="Model\WorkplanModel.cs" />
     <Compile Include="..\Moryx.Products.Management\Modification\PartialSerialization.cs" Link="Serialization\PartialSerialization.cs" />
   </ItemGroup>
-	<ItemGroup>
-		
 
-		<FrameworkReference Include="Microsoft.AspNetCore.App" Version="5.0.0" />
-	</ItemGroup>
-	<ItemGroup>
-	  <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Folder Include="Serialization\" />
-	</ItemGroup>
+  <ItemGroup>
+	<FrameworkReference Include="Microsoft.AspNetCore.App" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -1,4 +1,7 @@
-﻿using Moryx.AbstractionLayer.Products.Endpoints.Model;
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Products.Endpoints.Model;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Products.Management.Modification;
 using Moryx.Serialization;
@@ -12,7 +15,7 @@ using System.Reflection;
 
 namespace Moryx.AbstractionLayer.Products.Endpoints
 {
-    public class ProductConverter 
+    public class ProductConverter
     {
         private IProductManagementModification _productManagement;
 
@@ -27,7 +30,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             _productManagement = productManagement;
         }
         public ProductDefinitionModel ConvertProductType(Type productType)
-        {           
+        {
             return new()
             {
                 Name = productType.Name,
@@ -163,7 +166,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             return part;
         }
 
-        
+
         public IProductType ConvertProductBack(ProductModel source, ProductType converted)
         {
             // Copy base values
@@ -192,7 +195,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                 foreach (var r in recipes)
                     _productManagement.SaveRecipe(r);
             }
-               
+
 
             // Product is flat
             if (source.Properties is null)
@@ -399,7 +402,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             };
             return model;
         }
-       
+
 
         public ProductInstance ConvertProductInstanceBack(ProductInstanceModel model, IProductType type)
         {
@@ -432,6 +435,6 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             };
         }
 
-        
+
     }
 }

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Products.Management.Modification;
@@ -26,7 +29,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
         {
             _productManagement = productManagement;
             _productConverter = new ProductConverter(_productManagement);
-        }           
+        }
 
         #region importers
         [HttpGet]
@@ -88,12 +91,12 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             if (oldParameters == null)
                 return null;
 
-            var parameters = EntryConvert.UpdateInstance(oldParameters, currentParameters);            
+            var parameters = EntryConvert.UpdateInstance(oldParameters, currentParameters);
             return parameters;
         }
 
         #endregion
-        #region product type          
+        #region product type
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -127,7 +130,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                     productModels.Add(_productConverter.ConvertProduct(p, false));
                 return productModels.ToArray();
             }
-                
+
             var identityArray = WebUtility.HtmlEncode(identity).Split('-');
             if(identityArray.Length != 2)
                 return BadRequest($"Identity has wrong format. Must be identifier-revision");
@@ -143,7 +146,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
         public ActionResult<ProductModel[]> GetTypes(ProductQuery query)
         {
             var productTypes = _productManagement.LoadTypes(query);
-            var productModels = new List<ProductModel>();           
+            var productModels = new List<ProductModel>();
             foreach (var t in productTypes)
             {
                 productModels.Add(_productConverter.ConvertProduct(t, false));
@@ -192,7 +195,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             type = _productConverter.ConvertProductBack(modifiedType, (ProductType) type);
             return _productManagement.SaveType(type);
         }
-     
+
         [HttpPost]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -206,7 +209,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var identityArray = WebUtility.HtmlEncode(newIdentity).Split('-');
             if (identityArray.Length != 2)
                 return BadRequest($"Identity has wrong format. Must be identifier-revision");
-            var identity = new ProductIdentity(identityArray[0], Convert.ToInt16(identityArray[1]));           
+            var identity = new ProductIdentity(identityArray[0], Convert.ToInt16(identityArray[1]));
             var newProductType = _productManagement.Duplicate(template, identity);
             if (newProductType == null)
                 return BadRequest($"Error while duplicating");
@@ -245,7 +248,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                 return NotFound();
             return _productConverter.ConvertProductInstance(productInstance);
         }
-       
+
         [HttpGet]
         [Route("instances")]
         public ActionResult<ProductInstanceModel[]> GetInstances([FromQuery] long[] ids)
@@ -287,7 +290,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var productInstance = _productConverter.ConvertProductInstanceBack(instanceModel, productType);
            _productManagement.SaveInstance(productInstance);
             return Ok();
-        }       
+        }
 
         #endregion
         #region recipes

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementHub.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementHub.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.SignalR;
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Microsoft.AspNetCore.SignalR;
 using Moryx.Products.Management.Modification;
 using System.Threading.Tasks;
 

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/WorkplanController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/WorkplanController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.Products.Management.Modification;
 using Moryx.Workflows;
@@ -6,6 +9,7 @@ using System.Collections.Generic;
 
 namespace Moryx.AbstractionLayer.Products.Endpoints
 {
+    /// <summary>
     /// Definition of a REST API on the <see cref="IWorkplansVersions"/> facade.
     /// </summary>
     [ApiController]
@@ -69,7 +73,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                 return NotFound();
             return ProductConverter.ConvertWorkplan(workplan);
         }
-        
+
         [HttpDelete]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Moryx.AbstractionLayer.Resources.Endpoints.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0</TargetFrameworks>
-	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	  <Description>REST Api in order to interact with the resource management</Description>
-	  <CreatePackage>true</CreatePackage>
-	  <PackageTags>MORYX;IIoT;IoT;Resource</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>REST Api in order to interact with the resource management</Description>
+    <CreatePackage>true</CreatePackage>
+    <PackageTags>MORYX;IIoT;IoT;Resource</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,13 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-      <FrameworkReference Include="Microsoft.AspNetCore.App" Version="5.0.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
   </ItemGroup>
-
 
 </Project>

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -1,21 +1,20 @@
 ﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Moryx.AbstractionLayer.Resources;
-using Moryx.Resources.Interaction;
-using Moryx.Resources.Interaction.Converter;
-using Moryx.Serialization;
-using Moryx.Tools;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Moryx.Resources.Interaction;
+using Moryx.Resources.Interaction.Converter;
+using Moryx.Serialization;
+using Moryx.Tools;
 
-namespace Moryx.Resources.Management.Endpoints
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     /// <summary>
     /// Definition of a REST API on the <see cref="IResourceManagement"/> facade.

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceSerialization.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using Moryx.AbstractionLayer.Resources;
-using Moryx.Configuration;
-using Moryx.Container;
-using Moryx.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Moryx.Configuration;
+using Moryx.Container;
+using Moryx.Serialization;
 
-namespace Moryx.Resources.Management.Endpoints
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     internal class ResourceSerialization : PossibleValuesSerialization
     {

--- a/src/Moryx.Products.Management/Implementation/Storage/AutoConfigurator.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/AutoConfigurator.cs
@@ -175,15 +175,16 @@ namespace Moryx.Products.Management
             ValueProviderExecutor.Execute(config, new ValueProviderExecutorSettings().AddDefaultValueProvider());
 
             // Optionally try to configure property mappers
-            var propertyMapperConfig = config as IPropertyMappedConfiguration;
-            if (propertyMapperConfig != null)
+            if (config is IPropertyMappedConfiguration propertyMapperConfig)
             {
                 var remainingColumns = typeof(IGenericColumns).GetProperties()
                     .OrderBy(p => p.Name).ToList();
                 // TODO: Use type wrapper
                 var baseProperties = typeof(TBaseType).GetProperties();
 
-                var filteredProperties = targetType.GetProperties().Where(p => baseProperties.All(bp => bp.Name != p.Name))
+                var filteredProperties = targetType.GetProperties()
+                    .Where(p => baseProperties.All(bp => bp.Name != p.Name))
+                    .Where(p => p.GetSetMethod() != null)
                     .Where(p => !typeof(IProductPartLink).IsAssignableFrom(p.PropertyType) & !typeof(IEnumerable<IProductPartLink>).IsAssignableFrom(p.PropertyType))
                     .Where(p => !typeof(ProductInstance).IsAssignableFrom(p.PropertyType) & !typeof(IEnumerable<ProductInstance>).IsAssignableFrom(p.PropertyType))
                     .ToList();

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -30,12 +30,12 @@ namespace Moryx.Products.Management
         /// <summary>
         /// Recipe types
         /// </summary>
-        public IReadOnlyList<Type> RecipeTypes { get => RecipeStrategies.Select(rs => rs.Value.TargetType).ToList(); }
+        public IReadOnlyList<Type> RecipeTypes => RecipeStrategies.Select(rs => rs.Value.TargetType).ToList();
 
         /// <summary>
         /// Product types
         /// </summary>
-        public IReadOnlyList<Type> ProductTypes { get => TypeStrategies.Select(ts => ts.Value.TargetType).ToList(); }
+        public IReadOnlyList<Type> ProductTypes => TypeStrategies.Select(ts => ts.Value.TargetType).ToList();
 
         /// <summary>
         /// Optimized constructor delegate for the different product types
@@ -100,12 +100,14 @@ namespace Moryx.Products.Management
                 TypeStrategies[config.TargetType] = strategy;
                 TypeConstructors[config.TargetType] = ReflectionTool.ConstructorDelegate<ProductType>(strategy.TargetType);
             }
+
             // Create instance strategies
             foreach (var config in Config.InstanceStrategies)
             {
                 var strategy = StrategyFactory.CreateInstanceStrategy(config);
                 InstanceStrategies[config.TargetType] = strategy;
             }
+
             // Create link strategies
             foreach (var config in Config.LinkStrategies)
             {
@@ -128,6 +130,7 @@ namespace Moryx.Products.Management
 
                 LinkConstructors[$"{config.TargetType}.{config.PartName}"] = ReflectionTool.ConstructorDelegate<IProductPartLink>(linkType);
             }
+
             // Create recipe strategies
             foreach (var config in Config.RecipeStrategies)
             {
@@ -963,7 +966,7 @@ namespace Moryx.Products.Management
         {
             IDictionary<string, IProductLinkStrategy> IDictionary<string, IDictionary<string, IProductLinkStrategy>>.this[string key]
             {
-                get { return ContainsKey(key) ? this[key] : (this[key] = new Dictionary<string, IProductLinkStrategy>()); }
+                get => ContainsKey(key) ? this[key] : this[key] = new Dictionary<string, IProductLinkStrategy>();
                 set { /*You can not set the internal cache*/ }
             }
         }

--- a/src/Moryx.Products.Management/Implementation/Storage/TypeStrategyBase.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/TypeStrategyBase.cs
@@ -1,13 +1,8 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System;
 using System.Linq;
-using System.Linq.Expressions;
-using Moryx.AbstractionLayer;
-using Moryx.AbstractionLayer.Identity;
 using Moryx.AbstractionLayer.Products;
-using Moryx.Model;
 using Moryx.Products.Model;
 using Moryx.Tools;
 
@@ -26,6 +21,7 @@ namespace Moryx.Products.Management
     public abstract class TypeStrategyBase<TConfig> : StrategyBase<TConfig, ProductTypeConfiguration>, IProductTypeStrategy
         where TConfig : ProductTypeConfiguration
     {
+        /// <inheritdoc />
         public override void Initialize(ProductTypeConfiguration config)
         {
             base.Initialize(config);

--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/GenericTypeConfiguration.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/GenericTypeConfiguration.cs
@@ -16,7 +16,7 @@ namespace Moryx.Products.Management
     {
         public override string PluginName
         {
-            get { return nameof(GenericTypeStrategy); }
+            get => nameof(GenericTypeStrategy);
             set { }
         }
 

--- a/src/Moryx.Products.Management/Plugins/GenericStrategies/GenericTypeStrategy.cs
+++ b/src/Moryx.Products.Management/Plugins/GenericStrategies/GenericTypeStrategy.cs
@@ -2,16 +2,11 @@
 // Licensed under the Apache License, Version 2.0
 
 using System;
-using System.Linq;
 using System.Linq.Expressions;
-using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Products;
 using Moryx.Container;
-using Moryx.Model;
 using Moryx.Modules;
 using Moryx.Products.Model;
-using Moryx.Serialization;
-using Newtonsoft.Json;
 
 namespace Moryx.Products.Management
 {
@@ -34,7 +29,7 @@ namespace Moryx.Products.Management
         public override void Initialize(ProductTypeConfiguration config)
         {
             base.Initialize(config);
-            
+
             EntityMapper.Initialize(TargetType, Config);
         }
 

--- a/src/Moryx.Products.Samples/ProductTypes/WatchfaceType.cs
+++ b/src/Moryx.Products.Samples/ProductTypes/WatchfaceType.cs
@@ -37,6 +37,8 @@ namespace Moryx.Products.Samples
         [DisplayName("Color")]
         public int Color { get; set; }
 
+        public string NumbersString => string.Join(", ", Numbers);
+
         protected override ProductInstance Instantiate()
         {
             return new WatchfaceInstance();

--- a/src/Moryx.Resources.Management.Endpoints/Moryx.Resources.Management.Endpoints.csproj
+++ b/src/Moryx.Resources.Management.Endpoints/Moryx.Resources.Management.Endpoints.csproj
@@ -1,36 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>net5.0</TargetFrameworks>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<Description>REST Api in order to interact with the resource management</Description>
-		<CreatePackage>true</CreatePackage>
-		<PackageTags>MORYX;IIoT;IoT;Resource</PackageTags>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net5.0</TargetFrameworks>
+	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	  <Description>REST Api in order to interact with the resource management</Description>
+	  <CreatePackage>true</CreatePackage>
+	  <PackageTags>MORYX;IIoT;IoT;Resource</PackageTags>
+  </PropertyGroup>
 
-	<ItemGroup>
-	  <Compile Include="..\Moryx.Resources.Interaction\Converter\ResourceQueryConverter.cs" Link="Converter\ResourceQueryConverter.cs" />
-	  <Compile Include="..\Moryx.Resources.Interaction\Converter\ResourceToModelConverter.cs" Link="Converter\ResourceToModelConverter.cs" />
-	  <Compile Include="..\Moryx.Resources.Interaction\Models\ReferenceFilter.cs" Link="Models\ReferenceFilter.cs" />
-	  <Compile Include="..\Moryx.Resources.Interaction\Models\ReferenceTypeModel.cs" Link="Models\ReferenceTypeModel.cs" />
-	  <Compile Include="..\Moryx.Resources.Interaction\Models\ResourceModel.cs" Link="Models\ResourceModel.cs" />
-	  <Compile Include="..\Moryx.Resources.Interaction\Models\ResourceQuery.cs" Link="Models\ResourceQuery.cs" />
-	  <Compile Include="..\Moryx.Resources.Interaction\Models\ResourceReferenceModel.cs" Link="Models\ResourceReferenceModel.cs" />
-	  <Compile Include="..\Moryx.Resources.Interaction\Models\ResourceTypeModel.cs" Link="Models\ResourceTypeModel.cs" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Moryx.Resources.Interaction\Converter\ResourceQueryConverter.cs" Link="Converter\ResourceQueryConverter.cs" />
+    <Compile Include="..\Moryx.Resources.Interaction\Converter\ResourceToModelConverter.cs" Link="Converter\ResourceToModelConverter.cs" />
+    <Compile Include="..\Moryx.Resources.Interaction\Models\ReferenceFilter.cs" Link="Models\ReferenceFilter.cs" />
+    <Compile Include="..\Moryx.Resources.Interaction\Models\ReferenceTypeModel.cs" Link="Models\ReferenceTypeModel.cs" />
+    <Compile Include="..\Moryx.Resources.Interaction\Models\ResourceModel.cs" Link="Models\ResourceModel.cs" />
+    <Compile Include="..\Moryx.Resources.Interaction\Models\ResourceQuery.cs" Link="Models\ResourceQuery.cs" />
+    <Compile Include="..\Moryx.Resources.Interaction\Models\ResourceReferenceModel.cs" Link="Models\ResourceReferenceModel.cs" />
+    <Compile Include="..\Moryx.Resources.Interaction\Models\ResourceTypeModel.cs" Link="Models\ResourceTypeModel.cs" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+      <FrameworkReference Include="Microsoft.AspNetCore.App" Version="5.0.0" />
+  </ItemGroup>
 
-		<FrameworkReference Include="Microsoft.AspNetCore.App" Version="5.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\Moryx.AbstractionLayer\Moryx.AbstractionLayer.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Models\" />
-	</ItemGroup>
 
 </Project>

--- a/src/Moryx.Resources.Management.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.Resources.Management.Endpoints/ResourceManagementController.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Moryx.AbstractionLayer.Resources;
@@ -131,7 +134,7 @@ namespace Moryx.Resources.Management.Endpoints
                 EntryConvert.InvokeMethod(resource, method, _serialization);
 
             var model = new ResourceToModelConverter(_resourceTypeTree, _serialization).GetDetails(resource);
-            model.Methods = new MethodEntry[0]; // Reset methods because they can not be invoked on new objects
+            model.Methods = Array.Empty<MethodEntry>(); // Reset methods because they can not be invoked on new objects
 
             return model;
         }
@@ -144,7 +147,7 @@ namespace Moryx.Resources.Management.Endpoints
         {
             if (_resourceModification.GetAllResources<IResource>(r => r.Id == model.Id) is not null)
                 return Conflict($"The resource '{model.Id}' already exists.");
-            
+
             var id = _resourceModification.Create(_resourceTypeTree[model.Type].ResourceType, r => {
                 var resourcesToSave = new HashSet<long>();
                 var resourceCache = new Dictionary<long, Resource>();
@@ -178,9 +181,9 @@ namespace Moryx.Resources.Management.Endpoints
                     var id = _resourceModification.Create(_resourceTypeTree[model.Type].ResourceType, r => { });
                     resource = _resourceModification.Read<Resource>(model.Id, resource => resource);
                 }
-                else 
+                else
                     resource = _resourceModification.Read<Resource>(model.Id, resource => resource);
-            
+
             // Write to cache because following calls might only have an empty reference
             if (model.Id == 0)
                 cache[model.ReferenceId] = resource;
@@ -274,7 +277,6 @@ namespace Moryx.Resources.Management.Endpoints
                 }
             }
         }
-
 
         [HttpPut]
         [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/Moryx.Resources.Management.Endpoints/ResourceSerialization.cs
+++ b/src/Moryx.Resources.Management.Endpoints/ResourceSerialization.cs
@@ -1,4 +1,7 @@
-﻿using Moryx.AbstractionLayer.Resources;
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Resources;
 using Moryx.Configuration;
 using Moryx.Container;
 using Moryx.Serialization;
@@ -21,14 +24,13 @@ namespace Moryx.Resources.Management.Endpoints
         public override IEnumerable<PropertyInfo> GetProperties(Type sourceType)
         {
             return typeof(Resource).IsAssignableFrom(sourceType)
-                // 
                 ? base.GetProperties(sourceType).Where(p => p.GetCustomAttribute<EntrySerializeAttribute>()?.Mode == EntrySerializeMode.Always)
-                : EntrySerializeSerialization.Instance.GetProperties(sourceType);
+                : new EntrySerializeSerialization().GetProperties(sourceType);
         }
 
         public override IEnumerable<MethodInfo> GetMethods(Type sourceType)
         {
-            return EntrySerializeSerialization.Instance.GetMethods(sourceType);
+            return new EntrySerializeSerialization().GetMethods(sourceType);
         }
 
         private class ContainerMock : IContainer

--- a/src/StartProject.Asp/StartProject.Asp.csproj
+++ b/src/StartProject.Asp/StartProject.Asp.csproj
@@ -19,7 +19,7 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\Moryx.AbstractionLayer.Products.Endpoints\Moryx.AbstractionLayer.Products.Endpoints.csproj" />
 	  <ProjectReference Include="..\Moryx.Products.Management\Moryx.Products.Management.csproj" />
-	  <ProjectReference Include="..\Moryx.Resources.Management.Endpoints\Moryx.Resources.Management.Endpoints.csproj" />
+	  <ProjectReference Include="..\Moryx.AbstractionLayer.Resources.Endpoints\Moryx.AbstractionLayer.Resources.Endpoints.csproj" />
 	  <ProjectReference Include="..\Moryx.Resources.Management\Moryx.Resources.Management.csproj" />
 	  <ProjectReference Include="..\Moryx.Resources.Samples\Moryx.Resources.Samples.csproj" />
 	</ItemGroup>


### PR DESCRIPTION

- [Ignore read only properties in GenericTypeStrategy](https://github.com/PHOENIXCONTACT/MORYX-AbstractionLayer/commit/564dc35b6dab8e93f9bab27466292dcec6130f7e) 
  - closes #166
- [Harmonized endpoint project names](https://github.com/PHOENIXCONTACT/MORYX-AbstractionLayer/commit/acbc45e4d94062f001ee4a61fa8a82d6eb18c251)
- [Added license header and improved source quality](https://github.com/PHOENIXCONTACT/MORYX-AbstractionLayer/commit/4da10614d9db771bbedd41192282f487b54ae73c)