### PR TITLE
Removed recipes will automatically deleted during product saving

### DIFF
--- a/src/Moryx.AbstractionLayer.Products.Endpoints/HubMiddlewareExtension.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/HubMiddlewareExtension.cs
@@ -45,11 +45,11 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
 
     public class ProductManagementHubService : BackgroundService
     {
-        private readonly IProductManagementModification _productManagement;
+        private readonly IRecipeProductManagement _productManagement;
         private readonly IHubContext<ProductManagementHub> _hubContext;
         private readonly ProductConverter _converter;
 
-        public ProductManagementHubService(IProductManagementModification productManagement,
+        public ProductManagementHubService(IRecipeProductManagement productManagement,
             IHubContext<ProductManagementHub> hubContext)
         {
             _productManagement = productManagement ?? throw new ArgumentNullException(nameof(productManagement));

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -189,8 +189,16 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
 
                 ConvertRecipeBack(recipeModel, productRecipe, converted);
                 recipes.Add(productRecipe);
-            }           
-            _productManagement.SaveRecipes(source.Id, recipes);
+            }
+            if (recipes.Any())
+                foreach(var recipe in recipes)
+                    _productManagement.SaveRecipe(recipe);
+
+            // Delete recipes
+            var recipesOfProduct = _productManagement.GetRecipes(converted, RecipeClassification.CloneFilter);
+            foreach (var recipe in recipesOfProduct)
+                if (recipes.FirstOrDefault(r => r.Id == recipe.Id) == null)
+                    _productManagement.DeleteRecipe(recipe.Id);
 
             // Product is flat
             if (source.Properties is null)

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -17,7 +17,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     public class ProductConverter
     {
-        private IProductManagementModification _productManagement;
+        private IRecipeProductManagement _productManagement;
 
         // Null object pattern for identity
         private static readonly ProductIdentity EmptyIdentity = new ProductIdentity(string.Empty, 0);
@@ -25,7 +25,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
         private static readonly ICustomSerialization ProductSerialization = new PartialSerialization<ProductType>();
         private static readonly ICustomSerialization RecipeSerialization = new PartialSerialization<ProductionRecipe>();
 
-        public ProductConverter(IProductManagementModification productManagement)
+        public ProductConverter(IRecipeProductManagement productManagement)
         {
             _productManagement = productManagement;
         }
@@ -189,13 +189,8 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
 
                 ConvertRecipeBack(recipeModel, productRecipe, converted);
                 recipes.Add(productRecipe);
-            }
-            if (recipes.Any())
-            {
-                foreach (var r in recipes)
-                    _productManagement.SaveRecipe(r);
-            }
-
+            }           
+            _productManagement.SaveRecipes(source.Id, recipes);
 
             // Product is flat
             if (source.Properties is null)

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -198,7 +198,7 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
             var recipesOfProduct = _productManagement.GetRecipes(converted, RecipeClassification.CloneFilter);
             foreach (var recipe in recipesOfProduct)
                 if (recipes.FirstOrDefault(r => r.Id == recipe.Id) == null)
-                    _productManagement.DeleteRecipe(recipe.Id);
+                    _productManagement.RemoveRecipe(recipe.Id);
 
             // Product is flat
             if (source.Properties is null)

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
@@ -23,9 +23,9 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
     [Produces("application/json")]
     public class ProductManagementController : ControllerBase
     {
-        private readonly IProductManagementModification _productManagement;
+        private readonly IRecipeProductManagement _productManagement;
         private readonly ProductConverter _productConverter;
-        public ProductManagementController(IProductManagementModification productManagement)
+        public ProductManagementController(IRecipeProductManagement productManagement)
         {
             _productManagement = productManagement;
             _productConverter = new ProductConverter(_productManagement);

--- a/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
+++ b/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
@@ -165,9 +165,9 @@ namespace Moryx.AbstractionLayer.Products
     public interface IRecipeProductManagement : IProductManagementModification
     {
         /// <summary>
-        /// Delete Recipe
+        /// Remove Recipe by given id
         /// </summary>
-        void DeleteRecipe(long recipeId);
+        void RemoveRecipe(long recipeId);
 
     }
 }

--- a/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
+++ b/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
@@ -123,7 +123,7 @@ namespace Moryx.AbstractionLayer.Products
         IReadOnlyList<TInstance> GetInstances<TInstance>(Expression<Func<TInstance, bool>> selector)
             where TInstance : IProductInstance;
     }
-    
+
     /// <summary>
     /// Additional interface for type storage to search for product types by expression
     /// TODO: Remove in AL 6
@@ -156,5 +156,23 @@ namespace Moryx.AbstractionLayer.Products
         /// Delete a product by its id
         /// </summary>
         bool DeleteProduct(long id);
+    }
+
+    /// <summary>
+    /// Additional interface for recipe management
+    /// TODO: Remove in AL 6
+    /// </summary>
+    public interface IRecipeProductManagement : IProductManagementModification
+    {
+        /// <summary>
+        /// Will load all recipes by the given product
+        /// </summary>
+        IReadOnlyList<IProductRecipe> GetAllRecipesByProduct(IProductType productType);
+
+        /// <summary>
+        /// Saves multiple recipes
+        /// </summary>
+        void SaveRecipes(long productId, ICollection<IProductRecipe> recipes);
+
     }
 }

--- a/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
+++ b/src/Moryx.AbstractionLayer/Products/IProductManagement.cs
@@ -159,20 +159,15 @@ namespace Moryx.AbstractionLayer.Products
     }
 
     /// <summary>
-    /// Additional interface for recipe management
+    /// Additional interface for deleting recipes
     /// TODO: Remove in AL 6
     /// </summary>
     public interface IRecipeProductManagement : IProductManagementModification
     {
         /// <summary>
-        /// Will load all recipes by the given product
+        /// Delete Recipe
         /// </summary>
-        IReadOnlyList<IProductRecipe> GetAllRecipesByProduct(IProductType productType);
-
-        /// <summary>
-        /// Saves multiple recipes
-        /// </summary>
-        void SaveRecipes(long productId, ICollection<IProductRecipe> recipes);
+        void DeleteRecipe(long recipeId);
 
     }
 }

--- a/src/Moryx.Products.Management/Components/IProductStorage.cs
+++ b/src/Moryx.Products.Management/Components/IProductStorage.cs
@@ -84,6 +84,10 @@ namespace Moryx.Products.Management
         IReadOnlyList<TType> LoadTypes<TType>(Expression<Func<TType, bool>> selector);
     }
 
+    /// <summary>
+    /// Additional interface for removing a recipe
+    /// TODO: Remove in AL 6
+    /// </summary>
     public interface IProductRemoveRecipeStorage: IProductSearchStorage
     {
         /// <summary>

--- a/src/Moryx.Products.Management/Components/IProductStorage.cs
+++ b/src/Moryx.Products.Management/Components/IProductStorage.cs
@@ -83,4 +83,13 @@ namespace Moryx.Products.Management
         /// </summary>
         IReadOnlyList<TType> LoadTypes<TType>(Expression<Func<TType, bool>> selector);
     }
+
+    public interface IProductRemoveRecipeStorage: IProductSearchStorage
+    {
+        /// <summary>
+        /// Remove recipe by given recipeId
+        /// </summary>
+        void RemoveRecipe (long recipeId);
+    }
+
 }

--- a/src/Moryx.Products.Management/Components/IRecipeManagement.cs
+++ b/src/Moryx.Products.Management/Components/IRecipeManagement.cs
@@ -43,5 +43,10 @@ namespace Moryx.Products.Management
         /// Saves multiple recipes
         /// </summary>
         void Save(long productId, ICollection<IProductRecipe> recipes);
+
+        /// <summary>
+        /// Remove the recipe by the given identifier
+        /// </summary>
+        void Remove(long recipeId);
     }
 }

--- a/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
+++ b/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
@@ -285,18 +285,9 @@ namespace Moryx.Products.Management
             return ProductManager.DeleteType(id);
         }
 
-        public IReadOnlyList<IProductRecipe> GetAllRecipesByProduct(IProductType productType)
+        public void DeleteRecipe(long recipeId)
         {
-            ValidateHealthState();
-            if(productType == null)
-                throw new ArgumentException("ProductType is null");
-            return RecipeManagement.GetAllByProduct(productType);
-        }
-
-        public void SaveRecipes(long productId, ICollection<IProductRecipe> recipes)
-        {
-            ValidateHealthState();
-            RecipeManagement.Save(productId, recipes);
+            RecipeManagement.Remove(recipeId);
         }
     }
 }

--- a/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
+++ b/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
@@ -14,7 +14,7 @@ using Moryx.Workflows;
 
 namespace Moryx.Products.Management
 {
-    internal class ProductManagementFacade : IFacadeControl, IWorkplansVersions, IProductManagementModification
+    internal class ProductManagementFacade : IFacadeControl, IWorkplansVersions, IRecipeProductManagement
     {
         // Use this delegate in every call for clean health state management
         public Action ValidateHealthState { get; set; }
@@ -283,6 +283,20 @@ namespace Moryx.Products.Management
         {
             ValidateHealthState();
             return ProductManager.DeleteType(id);
+        }
+
+        public IReadOnlyList<IProductRecipe> GetAllRecipesByProduct(IProductType productType)
+        {
+            ValidateHealthState();
+            if(productType == null)
+                throw new ArgumentException("ProductType is null");
+            return RecipeManagement.GetAllByProduct(productType);
+        }
+
+        public void SaveRecipes(long productId, ICollection<IProductRecipe> recipes)
+        {
+            ValidateHealthState();
+            RecipeManagement.Save(productId, recipes);
         }
     }
 }

--- a/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
+++ b/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
@@ -285,7 +285,7 @@ namespace Moryx.Products.Management
             return ProductManager.DeleteType(id);
         }
 
-        public void DeleteRecipe(long recipeId)
+        public void RemoveRecipe(long recipeId)
         {
             RecipeManagement.Remove(recipeId);
         }

--- a/src/Moryx.Products.Management/Implementation/RecipeManagement.cs
+++ b/src/Moryx.Products.Management/Implementation/RecipeManagement.cs
@@ -19,7 +19,7 @@ namespace Moryx.Products.Management
     {
         #region Dependencies
 
-        public IProductStorage Storage { get; set; }
+        public IProductRemoveRecipeStorage Storage { get; set; }
 
         public IUnitOfWorkFactory<ProductsContext> ModelFactory { get; set; }
 
@@ -56,6 +56,11 @@ namespace Moryx.Products.Management
             Storage.SaveRecipes(productId, recipes);
             foreach (var recipe in recipes)
                 RaiseRecipeChanged(recipe);
+        }
+
+        public void Remove(long recipeId)
+        {
+            Storage.RemoveRecipe(recipeId);
         }
 
         public IReadOnlyList<Workplan> LoadAllWorkplans()
@@ -143,7 +148,7 @@ namespace Moryx.Products.Management
                 return entity.Id;
             }
         }
-
+       
         public void DeleteWorkplan(long workplanId)
         {
             using (var uow = ModelFactory.Create())

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -24,8 +24,8 @@ namespace Moryx.Products.Management
     /// Base class for product storage. Contains basic functionality to load and save a product.
     /// Also has the possibility to store a version to each save.
     /// </summary>
-    [Plugin(LifeCycle.Singleton, typeof(IProductStorage), typeof(IProductSearchStorage), typeof(IConfiguredTypesProvider))]
-    internal class ProductStorage : IProductSearchStorage, IConfiguredTypesProvider
+    [Plugin(LifeCycle.Singleton, typeof(IProductStorage), typeof(IProductSearchStorage), typeof(IConfiguredTypesProvider),typeof(IProductRemoveRecipeStorage))]
+    internal class ProductStorage : IProductRemoveRecipeStorage, IConfiguredTypesProvider
     {
         /// <summary>
         /// Recipe types
@@ -243,6 +243,21 @@ namespace Moryx.Products.Management
                               where recipes.All(r => r.Id != dbRecipe.Id)
                               select dbRecipe;
                 recipeRepo.RemoveRange(deleted);
+
+                uow.SaveChanges();
+            }
+        }
+
+        /// <inheritdoc />
+        public void RemoveRecipe(long recipeId)
+        {
+            using (var uow = Factory.Create())
+            {
+                // Prepare required repos   
+                var recipeRepo = uow.GetRepository<IProductRecipeEntityRepository>();
+
+                var deletedRecipe = recipeRepo.GetByKey(recipeId);         
+                recipeRepo.Remove(deletedRecipe);
 
                 uow.SaveChanges();
             }


### PR DESCRIPTION
Created Interfaces IRecipeProductManagement and IProductRemoveRecipeStorage in order to delete a recipe. In the product converter all recipes will be automatically removed during product saving.