### PR TITLE
Fix creating product revisions with endpoint

### DIFF
--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -195,11 +195,14 @@ namespace Moryx.AbstractionLayer.Products.Endpoints
                     _productManagement.SaveRecipe(recipe);
 
             // Delete recipes
-            var recipesOfProduct = _productManagement.GetRecipes(converted, RecipeClassification.CloneFilter);
-            foreach (var recipe in recipesOfProduct)
-                if (recipes.FirstOrDefault(r => r.Id == recipe.Id) == null)
-                    _productManagement.RemoveRecipe(recipe.Id);
-
+            if(converted.Id != 0)
+            {
+                var recipesOfProduct = _productManagement.GetRecipes(converted, RecipeClassification.CloneFilter);
+                foreach (var recipe in recipesOfProduct)
+                    if (recipes.FirstOrDefault(r => r.Id == recipe.Id) == null)
+                        _productManagement.RemoveRecipe(recipe.Id);
+            }
+            
             // Product is flat
             if (source.Properties is null)
                 return converted;

--- a/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
+++ b/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
@@ -140,6 +140,8 @@ namespace Moryx.Products.Management
         {
             ValidateHealthState();
             var recipes = RecipeManagement.GetRecipes(productType, classification);
+            if (recipes == null)
+                return null;
             return recipes.Select(ReplaceOrigin).ToArray();
         }
 


### PR DESCRIPTION
Product revisions couldn't be created with the endpoint, because  an error will be thrown, if you try to load recipes of a product, which does not exist