### PR TITLE
Invoking a method without return value creates no error in the web UI

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -108,8 +108,6 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
                 entry = EntryConvert.InvokeMethod(r.Descriptor, new MethodEntry { Name = method, Parameters = parameters }, _serialization);
                 return true;
             });
-            if (entry is null)
-                return Conflict("Method could not be invoked.");
 
             return entry;
         }


### PR DESCRIPTION
Up to now, a conflict would be sent to the web ui, if a method without return vlaue is sent