### PR TITLE
Align namespaces and fix entity defintions for products

### DIFF
--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/PartConnector.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/PartConnector.cs
@@ -4,7 +4,7 @@
 using System.Runtime.Serialization;
 using Moryx.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class PartConnector

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/PartModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/PartModel.cs
@@ -4,7 +4,7 @@
 using System.Runtime.Serialization;
 using Moryx.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class PartModel

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductCustomization.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductCustomization.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class ProductCustomization

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductDefinitionModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductDefinitionModel.cs
@@ -4,7 +4,7 @@
 using System.Runtime.Serialization;
 using Moryx.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class ProductDefinitionModel

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductFileModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductFileModel.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class ProductFileModel

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductImporter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductImporter.cs
@@ -4,7 +4,7 @@
 using System.Runtime.Serialization;
 using Moryx.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class ProductImporter

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductInstanceModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductInstanceModel.cs
@@ -4,7 +4,7 @@
 using Moryx.Serialization;
 using System.Runtime.Serialization;
 
-namespace Moryx.AbstractionLayer.Products.Endpoints.Model
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class ProductInstanceModel

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/ProductModel.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization;
 using Moryx.AbstractionLayer.Products;
 using Moryx.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class ProductModel

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/RecipeClassificationModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/RecipeClassificationModel.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     /// <summary>
     /// Webservice compatible recipe classification enum

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/RecipeDefinitionModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/RecipeDefinitionModel.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class RecipeDefinitionModel

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/RecipeModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/RecipeModel.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.Runtime.Serialization;
-using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     /// <summary>
     /// DTO representation of a recipe

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/Model/WorkplanModel.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/Model/WorkplanModel.cs
@@ -4,7 +4,7 @@
 using System.Runtime.Serialization;
 using Moryx.Workflows;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     [DataContract]
     public class WorkplanModel

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/PartialSerialization.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/PartialSerialization.cs
@@ -9,7 +9,7 @@ using Moryx.AbstractionLayer.Products;
 using Moryx.Configuration;
 using Moryx.Serialization;
 
-namespace Moryx.Products.Management.Modification
+namespace Moryx.AbstractionLayer.Products.Endpoints
 {
     /// <summary>
     /// Specialized serialization that only considers properties of derived classes

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductConverter.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using Moryx.AbstractionLayer.Products.Endpoints.Model;
 using Moryx.AbstractionLayer.Recipes;
-using Moryx.Products.Management.Modification;
 using Moryx.Serialization;
 using Moryx.Tools;
 using Moryx.Workflows;

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementController.cs
@@ -4,12 +4,10 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Recipes;
-using Moryx.Products.Management.Modification;
 using Moryx.Tools;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Moryx.AbstractionLayer.Products.Endpoints.Model;
 using Moryx.Serialization;
 using System.Net;
 

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementHub.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/ProductManagementHub.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 
 using Microsoft.AspNetCore.SignalR;
-using Moryx.Products.Management.Modification;
 using System.Threading.Tasks;
 
 namespace Moryx.AbstractionLayer.Products.Endpoints

--- a/src/Moryx.AbstractionLayer.Products.Endpoints/WorkplanController.cs
+++ b/src/Moryx.AbstractionLayer.Products.Endpoints/WorkplanController.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Moryx.Products.Management.Modification;
 using Moryx.Workflows;
 using System.Collections.Generic;
 

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ModelToResourceConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ModelToResourceConverter.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.Serialization;
 
-namespace Moryx.Resources.Interaction.Converter
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     /// <summary>
     /// Converts ResourceModel to Resource

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceQueryConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceQueryConverter.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.Serialization;
 
-namespace Moryx.Resources.Interaction.Converter
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     internal class ResourceQueryConverter : ResourceToModelConverter
     {

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
@@ -11,7 +11,7 @@ using Moryx.AbstractionLayer.Resources;
 using Moryx.Serialization;
 using Moryx.Tools;
 
-namespace Moryx.Resources.Interaction.Converter
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     /// <summary>
     /// Converts Resources to ResourceModel

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ReferenceFilter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ReferenceFilter.cs
@@ -4,7 +4,7 @@
 using System.Runtime.Serialization;
 using Moryx.AbstractionLayer.Resources;
 
-namespace Moryx.Resources.Interaction
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     /// <summary>
     /// Enum to classify the current value of the reference property

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ReferenceTypeModel.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ReferenceTypeModel.cs
@@ -4,7 +4,7 @@
 using System.Runtime.Serialization;
 using Moryx.AbstractionLayer.Resources;
 
-namespace Moryx.Resources.Interaction
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     /// <summary>
     /// Type model for a reference property on a resource type

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ResourceModel.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ResourceModel.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.Serialization;
 
-namespace Moryx.Resources.Interaction
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     /// <summary>
     /// Base model used by details view and tree

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ResourceQuery.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ResourceQuery.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.Serialization;
 
-namespace Moryx.Resources.Interaction
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     /// <summary>
     /// Filter object to fetch resources from the server

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ResourceReferenceModel.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ResourceReferenceModel.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace Moryx.Resources.Interaction
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     /// <summary>
     /// DTO that represents the reference of one resource with another

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ResourceTypeModel.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Models/ResourceTypeModel.cs
@@ -4,7 +4,7 @@
 using System.Runtime.Serialization;
 using Moryx.Serialization;
 
-namespace Moryx.Resources.Interaction
+namespace Moryx.AbstractionLayer.Resources.Endpoints
 {
     /// <summary>
     /// Type item for the tree

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Moryx.Resources.Interaction;
-using Moryx.Resources.Interaction.Converter;
 using Moryx.Serialization;
 using Moryx.Tools;
 

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -874,7 +874,7 @@ namespace Moryx.Products.Management
                     // Update all parts that are also present as entities
                     foreach (var partEntity in partEntityGroups[partGroup.Key.Name])
                     {
-                        var part = partGroup.Value.First(p => p.PartLink.Id == partEntity.PartLinkId);
+                        var part = partGroup.Value.First(p => p.PartLink.Id == partEntity.PartLinkEntityId);
                         TransformInstance(uow, partEntity, part);
                     }
                 }
@@ -885,7 +885,7 @@ namespace Moryx.Products.Management
                     var partArticles = TransformInstances(uow, partCollection);
                     for (var index = 0; index < partArticles.Length; index++)
                     {
-                        partArticles[index].PartLink = partLinks.Find(pl => pl?.Id == partCollection[index].PartLinkId.Value);
+                        partArticles[index].PartLink = partLinks.Find(pl => pl?.Id == partCollection[index].PartLinkEntityId.Value);
                     }
 
                     if (typeof(ProductInstance).IsAssignableFrom(partGroup.Key.PropertyType) && partArticles.Length == 0)
@@ -958,7 +958,7 @@ namespace Moryx.Products.Management
                         continue;
 
                     partEntity.Parent = archived;
-                    partEntity.PartLinkId = part.PartLink.Id;
+                    partEntity.PartLinkEntityId = part.PartLink.Id;
                 }
             }
 

--- a/src/Moryx.Products.Model/Entities/ProductInstanceEntity.cs
+++ b/src/Moryx.Products.Model/Entities/ProductInstanceEntity.cs
@@ -15,7 +15,7 @@ namespace Moryx.Products.Model
 
         public virtual long? ParentId { get; set; }
 
-        public virtual long? PartLinkId { get; set; }
+        public virtual long? PartLinkEntityId { get; set; }
 
         public virtual ProductTypeEntity Product { get; set; }
 

--- a/src/Moryx.Products.Model/Entities/WorkplanConnectorReferenceEntity.cs
+++ b/src/Moryx.Products.Model/Entities/WorkplanConnectorReferenceEntity.cs
@@ -13,7 +13,7 @@ namespace Moryx.Products.Model
 
         public virtual long? ConnectorId { get; set; }
 
-        public virtual long StepId { get; set; }
+        public virtual long WorkplanStepId { get; set; }
 
         public virtual WorkplanConnectorEntity Connector { get; set; }
 

--- a/src/Moryx.Products.Model/Entities/WorkplanOutputDescriptionEntity.cs
+++ b/src/Moryx.Products.Model/Entities/WorkplanOutputDescriptionEntity.cs
@@ -15,7 +15,7 @@ namespace Moryx.Products.Model
 
         public virtual long MappingValue { get; set; }
 
-        public virtual long StepEntityId { get; set; }
+        public virtual long WorkplanStepId { get; set; }
 
         public virtual WorkplanStepEntity WorkplanStep { get; set; }
     }

--- a/src/Moryx.Products.Model/Migrations/20220906133824_InitialCreate.Designer.cs
+++ b/src/Moryx.Products.Model/Migrations/20220906133824_InitialCreate.Designer.cs
@@ -7,10 +7,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Moryx.Products.Model;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
-namespace Moryx.Products.Model.Migrations
+namespace Moryx.Products.Model.Model.Migrations
 {
     [DbContext(typeof(ProductsContext))]
-    [Migration("20211104134724_InitialCreate")]
+    [Migration("20220906133824_InitialCreate")]
     partial class InitialCreate
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -209,7 +209,7 @@ namespace Moryx.Products.Model.Migrations
                     b.Property<long?>("ParentId")
                         .HasColumnType("bigint");
 
-                    b.Property<long?>("PartLinkId")
+                    b.Property<long?>("PartLinkEntityId")
                         .HasColumnType("bigint");
 
                     b.Property<long>("ProductId")
@@ -246,7 +246,7 @@ namespace Moryx.Products.Model.Migrations
 
                     b.HasIndex("ParentId");
 
-                    b.HasIndex("PartLinkId");
+                    b.HasIndex("PartLinkEntityId");
 
                     b.HasIndex("ProductId");
 
@@ -557,10 +557,7 @@ namespace Moryx.Products.Model.Migrations
                     b.Property<int>("Role")
                         .HasColumnType("integer");
 
-                    b.Property<long>("StepId")
-                        .HasColumnType("bigint");
-
-                    b.Property<long?>("WorkplanStepId")
+                    b.Property<long>("WorkplanStepId")
                         .HasColumnType("bigint");
 
                     b.HasKey("Id");
@@ -624,12 +621,12 @@ namespace Moryx.Products.Model.Migrations
                     b.Property<int>("OutputType")
                         .HasColumnType("integer");
 
-                    b.Property<long>("StepEntityId")
+                    b.Property<long>("WorkplanStepId")
                         .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("StepEntityId");
+                    b.HasIndex("WorkplanStepId");
 
                     b.ToTable("WorkplanOutputDescriptions");
                 });
@@ -730,7 +727,7 @@ namespace Moryx.Products.Model.Migrations
 
                     b.HasOne("Moryx.Products.Model.PartLinkEntity", "PartLinkEntity")
                         .WithMany()
-                        .HasForeignKey("PartLinkId");
+                        .HasForeignKey("PartLinkEntityId");
 
                     b.HasOne("Moryx.Products.Model.ProductTypeEntity", "Product")
                         .WithMany()
@@ -785,14 +782,16 @@ namespace Moryx.Products.Model.Migrations
 
                     b.HasOne("Moryx.Products.Model.WorkplanStepEntity", "WorkplanStep")
                         .WithMany("Connectors")
-                        .HasForeignKey("WorkplanStepId");
+                        .HasForeignKey("WorkplanStepId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("Moryx.Products.Model.WorkplanOutputDescriptionEntity", b =>
                 {
                     b.HasOne("Moryx.Products.Model.WorkplanStepEntity", "WorkplanStep")
                         .WithMany("OutputDescriptions")
-                        .HasForeignKey("StepEntityId")
+                        .HasForeignKey("WorkplanStepId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });

--- a/src/Moryx.Products.Model/Migrations/20220906133824_InitialCreate.cs
+++ b/src/Moryx.Products.Model/Migrations/20220906133824_InitialCreate.cs
@@ -2,7 +2,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
-namespace Moryx.Products.Model.Migrations
+namespace Moryx.Products.Model.Model.Migrations
 {
     public partial class InitialCreate : Migration
     {
@@ -130,8 +130,7 @@ namespace Moryx.Products.Model.Migrations
                     Index = table.Column<int>(nullable: false),
                     Role = table.Column<int>(nullable: false),
                     ConnectorId = table.Column<long>(nullable: true),
-                    StepId = table.Column<long>(nullable: false),
-                    WorkplanStepId = table.Column<long>(nullable: true)
+                    WorkplanStepId = table.Column<long>(nullable: false)
                 },
                 constraints: table =>
                 {
@@ -149,7 +148,7 @@ namespace Moryx.Products.Model.Migrations
                         principalSchema: "public",
                         principalTable: "WorkplanSteps",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
@@ -163,14 +162,14 @@ namespace Moryx.Products.Model.Migrations
                     OutputType = table.Column<int>(nullable: false),
                     Name = table.Column<string>(nullable: true),
                     MappingValue = table.Column<long>(nullable: false),
-                    StepEntityId = table.Column<long>(nullable: false)
+                    WorkplanStepId = table.Column<long>(nullable: false)
                 },
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_WorkplanOutputDescriptions", x => x.Id);
                     table.ForeignKey(
-                        name: "FK_WorkplanOutputDescriptions_WorkplanSteps_StepEntityId",
-                        column: x => x.StepEntityId,
+                        name: "FK_WorkplanOutputDescriptions_WorkplanSteps_WorkplanStepId",
+                        column: x => x.WorkplanStepId,
                         principalSchema: "public",
                         principalTable: "WorkplanSteps",
                         principalColumn: "Id",
@@ -187,7 +186,7 @@ namespace Moryx.Products.Model.Migrations
                     State = table.Column<long>(nullable: false),
                     ProductId = table.Column<long>(nullable: false),
                     ParentId = table.Column<long>(nullable: true),
-                    PartLinkId = table.Column<long>(nullable: true),
+                    PartLinkEntityId = table.Column<long>(nullable: true),
                     Integer1 = table.Column<long>(nullable: false),
                     Integer2 = table.Column<long>(nullable: false),
                     Integer3 = table.Column<long>(nullable: false),
@@ -462,10 +461,10 @@ namespace Moryx.Products.Model.Migrations
                 column: "ParentId");
 
             migrationBuilder.CreateIndex(
-                name: "IX_ProductInstances_PartLinkId",
+                name: "IX_ProductInstances_PartLinkEntityId",
                 schema: "public",
                 table: "ProductInstances",
-                column: "PartLinkId");
+                column: "PartLinkEntityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ProductInstances_ProductId",
@@ -522,10 +521,10 @@ namespace Moryx.Products.Model.Migrations
                 column: "WorkplanStepId");
 
             migrationBuilder.CreateIndex(
-                name: "IX_WorkplanOutputDescriptions_StepEntityId",
+                name: "IX_WorkplanOutputDescriptions_WorkplanStepId",
                 schema: "public",
                 table: "WorkplanOutputDescriptions",
-                column: "StepEntityId");
+                column: "WorkplanStepId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkplanReferences_SourceId",
@@ -562,10 +561,10 @@ namespace Moryx.Products.Model.Migrations
                 onDelete: ReferentialAction.Cascade);
 
             migrationBuilder.AddForeignKey(
-                name: "FK_ProductInstances_PartLinks_PartLinkId",
+                name: "FK_ProductInstances_PartLinks_PartLinkEntityId",
                 schema: "public",
                 table: "ProductInstances",
-                column: "PartLinkId",
+                column: "PartLinkEntityId",
                 principalSchema: "public",
                 principalTable: "PartLinks",
                 principalColumn: "Id",

--- a/src/Moryx.Products.Model/Migrations/ProductsContextModelSnapshot.cs
+++ b/src/Moryx.Products.Model/Migrations/ProductsContextModelSnapshot.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Moryx.Products.Model;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
-namespace Moryx.Products.Model.Migrations
+namespace Moryx.Products.Model.Model.Migrations
 {
     [DbContext(typeof(ProductsContext))]
     partial class ProductsContextModelSnapshot : ModelSnapshot
@@ -207,7 +207,7 @@ namespace Moryx.Products.Model.Migrations
                     b.Property<long?>("ParentId")
                         .HasColumnType("bigint");
 
-                    b.Property<long?>("PartLinkId")
+                    b.Property<long?>("PartLinkEntityId")
                         .HasColumnType("bigint");
 
                     b.Property<long>("ProductId")
@@ -244,7 +244,7 @@ namespace Moryx.Products.Model.Migrations
 
                     b.HasIndex("ParentId");
 
-                    b.HasIndex("PartLinkId");
+                    b.HasIndex("PartLinkEntityId");
 
                     b.HasIndex("ProductId");
 
@@ -555,10 +555,7 @@ namespace Moryx.Products.Model.Migrations
                     b.Property<int>("Role")
                         .HasColumnType("integer");
 
-                    b.Property<long>("StepId")
-                        .HasColumnType("bigint");
-
-                    b.Property<long?>("WorkplanStepId")
+                    b.Property<long>("WorkplanStepId")
                         .HasColumnType("bigint");
 
                     b.HasKey("Id");
@@ -622,12 +619,12 @@ namespace Moryx.Products.Model.Migrations
                     b.Property<int>("OutputType")
                         .HasColumnType("integer");
 
-                    b.Property<long>("StepEntityId")
+                    b.Property<long>("WorkplanStepId")
                         .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("StepEntityId");
+                    b.HasIndex("WorkplanStepId");
 
                     b.ToTable("WorkplanOutputDescriptions");
                 });
@@ -728,7 +725,7 @@ namespace Moryx.Products.Model.Migrations
 
                     b.HasOne("Moryx.Products.Model.PartLinkEntity", "PartLinkEntity")
                         .WithMany()
-                        .HasForeignKey("PartLinkId");
+                        .HasForeignKey("PartLinkEntityId");
 
                     b.HasOne("Moryx.Products.Model.ProductTypeEntity", "Product")
                         .WithMany()
@@ -783,14 +780,16 @@ namespace Moryx.Products.Model.Migrations
 
                     b.HasOne("Moryx.Products.Model.WorkplanStepEntity", "WorkplanStep")
                         .WithMany("Connectors")
-                        .HasForeignKey("WorkplanStepId");
+                        .HasForeignKey("WorkplanStepId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("Moryx.Products.Model.WorkplanOutputDescriptionEntity", b =>
                 {
                     b.HasOne("Moryx.Products.Model.WorkplanStepEntity", "WorkplanStep")
                         .WithMany("OutputDescriptions")
-                        .HasForeignKey("StepEntityId")
+                        .HasForeignKey("WorkplanStepId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });

--- a/src/Moryx.Products.Model/ProductsContext.cs
+++ b/src/Moryx.Products.Model/ProductsContext.cs
@@ -99,7 +99,7 @@ namespace Moryx.Products.Model
             modelBuilder.Entity<ProductInstanceEntity>()
                 .HasOne(a => a.PartLinkEntity)
                 .WithMany()
-                .HasForeignKey(a => a.PartLinkId);
+                .HasForeignKey(a => a.PartLinkEntityId);
 
             // Connector
             modelBuilder.Entity<WorkplanConnectorEntity>()
@@ -119,7 +119,7 @@ namespace Moryx.Products.Model
             modelBuilder.Entity<WorkplanStepEntity>()
                 .HasMany(s => s.OutputDescriptions)
                 .WithOne(o => o.WorkplanStep).IsRequired()
-                .HasForeignKey(o => o.StepEntityId);
+                .HasForeignKey(o => o.WorkplanStepId);
 
             modelBuilder.Entity<WorkplanStepEntity>()
                 .HasOne(s => s.Workplan)

--- a/src/StartProject.Asp/StartProject.Asp.csproj
+++ b/src/StartProject.Asp/StartProject.Asp.csproj
@@ -11,6 +11,10 @@
 		<PackageReference Include="Moryx.Runtime.Kernel" />
 		<PackageReference Include="Moryx.Runtime.Endpoints" />
 		<PackageReference Include="Moryx.Maintenance.Web" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/ProductStorageTests.cs
@@ -865,7 +865,7 @@ namespace Moryx.Products.IntegrationTests
                 var parts = root.Parts;
                 Assert.AreEqual(1, parts.Count, "Invalid number of parts!"); // needles will be skipped for saving
 
-                var single = parts.FirstOrDefault(p => p.PartLinkId == watch.WatchFace.Id);
+                var single = parts.FirstOrDefault(p => p.PartLinkEntityId == watch.WatchFace.Id);
                 Assert.NotNull(single, "Single part not saved!");
             }
 


### PR DESCRIPTION
While the files of the models in the Endpoints projects were moved while updating to future, the namespaces were not.

Some of the reference properties in the database models were renamed in the update of EF. The respective Id properties for the foreign keys were not, however. This PR fixes that