### PR TITLE
Add coordinates (`PositionX`, `PositionY`) to `WorkplanStepEntity`

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-    <MoryxCoreVersion>4.0.0-future.673</MoryxCoreVersion>
+    <MoryxCoreVersion>4.0.0-future.677</MoryxCoreVersion>
   </PropertyGroup>
 
   <Import Project=".build\Common.props" Condition="'$(CreatePackage)' == 'true'" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-    <MoryxCoreVersion>4.0.0-future.666</MoryxCoreVersion>
+    <MoryxCoreVersion>4.0.0-future.673</MoryxCoreVersion>
   </PropertyGroup>
 
   <Import Project=".build\Common.props" Condition="'$(CreatePackage)' == 'true'" />

--- a/src/Moryx.AbstractionLayer/Workplan/WorkplanExtensions.cs
+++ b/src/Moryx.AbstractionLayer/Workplan/WorkplanExtensions.cs
@@ -137,7 +137,7 @@ namespace Moryx.AbstractionLayer
         /// <returns></returns>
         public static IConnector AddConnector(this Workplan workplan, string name, NodeClassification classification)
         {
-            var connector = Workflow.CreateConnector(name, classification);
+            var connector = WorkplanInstance.CreateConnector(name, classification);
             workplan.Add(connector);
             return connector;
         }
@@ -169,7 +169,7 @@ namespace Moryx.AbstractionLayer
         public static void Validate(this IWorkplan workplan)
         {
             const ValidationAspect aspects = ValidationAspect.DeadEnd | ValidationAspect.InfiniteLoop | ValidationAspect.LoneWolf | ValidationAspect.LuckyStreak;
-            var result = Workflow.Validate(workplan, aspects);
+            var result = WorkplanInstance.Validate(workplan, aspects);
 
             if (result.Success)
                 return;

--- a/src/Moryx.Products.Management/Implementation/RecipeStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/RecipeStorage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Products;
@@ -117,6 +118,7 @@ namespace Moryx.Products.Management
                 var step = (WorkplanStepBase)Activator.CreateInstance(type, true);
                 step.Id = stepEntity.StepId;
                 step.Name = stepEntity.Name;
+                step.Position = new Point(stepEntity.PositionX, stepEntity.PositionY);
 
                 // Restore output descriptions
                 step.OutputDescriptions = new OutputDescription[stepEntity.OutputDescriptions.Count];
@@ -263,7 +265,7 @@ namespace Moryx.Products.Management
                 {
                     var stepType = step.GetType();
                     var assemblyName = stepType.Assembly.GetName().Name;
-                    stepEntity = stepRepo.Create(step.Id, step.Name, assemblyName, stepType.Namespace, stepType.Name);
+                    stepEntity = stepRepo.Create(step.Id, step.Name, assemblyName, stepType.Namespace, stepType.Name, step.Position.X, step.Position.Y);
                     workplanEntity.Steps.Add(stepEntity);
                 }
                 else

--- a/src/Moryx.Products.Model/API/IWorkplanStepRepository.cs
+++ b/src/Moryx.Products.Model/API/IWorkplanStepRepository.cs
@@ -13,6 +13,6 @@ namespace Moryx.Products.Model
         /// <summary>
         /// Creates instance with all not nullable properties prefilled
         /// </summary>
-        WorkplanStepEntity Create(long stepId, string name, string assembly, string nameSpace, string classname);
+        WorkplanStepEntity Create(long stepId, string name, string assembly, string nameSpace, string classname, int positionX, int positionY);
     }
 }

--- a/src/Moryx.Products.Model/Entities/WorkplanStepEntity.cs
+++ b/src/Moryx.Products.Model/Entities/WorkplanStepEntity.cs
@@ -24,6 +24,10 @@ namespace Moryx.Products.Model
 
         public virtual long? SubWorkplanId { get; set; }
 
+        public virtual int PositionX { get; set; }
+
+        public virtual int PositionY { get; set; }
+
         public virtual WorkplanEntity Workplan { get; set; }
 
         public virtual WorkplanEntity SubWorkplan { get; set; }

--- a/src/Moryx.Products.Model/Migrations/20220906133824_InitialCreate.cs
+++ b/src/Moryx.Products.Model/Migrations/20220906133824_InitialCreate.cs
@@ -99,7 +99,9 @@ namespace Moryx.Products.Model.Model.Migrations
                     Classname = table.Column<string>(nullable: true),
                     Parameters = table.Column<string>(nullable: true),
                     WorkplanId = table.Column<long>(nullable: false),
-                    SubWorkplanId = table.Column<long>(nullable: true)
+                    SubWorkplanId = table.Column<long>(nullable: true),
+                    PositionX = table.Column<int>(nullable: false, defaultValue: 0),
+                    PositionY = table.Column<int>(nullable: false, defaultValue: 0)
                 },
                 constraints: table =>
                 {

--- a/src/Moryx.Products.Model/Migrations/ProductsContextModelSnapshot.cs
+++ b/src/Moryx.Products.Model/Migrations/ProductsContextModelSnapshot.cs
@@ -685,6 +685,14 @@ namespace Moryx.Products.Model.Model.Migrations
                     b.Property<long>("WorkplanId")
                         .HasColumnType("bigint");
 
+                    b.Property<int>("PositionX")
+                        .HasColumnType("integer")
+                        .HasDefaultValue(0);
+
+                    b.Property<int>("PositionY")
+                        .HasColumnType("integer")
+                        .HasDefaultValue(0);
+
                     b.HasKey("Id");
 
                     b.HasIndex("SubWorkplanId");

--- a/src/Tests/Moryx.Products.IntegrationTests/RecipeStorage/RecipeStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/RecipeStorage/RecipeStorageTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.Drawing;
 using System.Linq;
 using Moq;
 using Moryx.AbstractionLayer.Recipes;
@@ -9,6 +10,7 @@ using Moryx.Model.Repositories;
 using Moryx.Products.Management;
 using Moryx.Products.Model;
 using Moryx.Workplans;
+using Moryx.Workplans.WorkplanSteps;
 using NUnit.Framework;
 
 namespace Moryx.Products.IntegrationTests
@@ -78,6 +80,9 @@ namespace Moryx.Products.IntegrationTests
                 var loadedStep = loadedSteps.FirstOrDefault(s => s.Id == step.Id);
                 Assert.NotNull(loadedStep);
                 Assert.AreEqual(step.GetType(), loadedStep.GetType());
+                Assert.AreEqual(step.Position.X, loadedStep.Position.X, "Workplan step position: x coordinate not as expected");
+                Assert.AreEqual(step.Position.Y, loadedStep.Position.Y, "Workplan step position: y coordinate not as expected");
+
                 for (int index = 0; index < step.Inputs.Length; index++)
                 {
                     Assert.AreEqual(step.Inputs[index].Id, loadedStep.Inputs[index].Id);
@@ -110,25 +115,29 @@ namespace Moryx.Products.IntegrationTests
             var mount = new TaskA
             {
                 Inputs = { [0] = start },
-                Outputs = { [0] = inter1, [1] = end, [2] = end }
+                Outputs = { [0] = inter1, [1] = end, [2] = end },
+                Position = new Point(1, 2),
             };
 
             var identity = new TaskB
             {
                 Inputs = { [0] = inter1 },
-                Outputs = { [0] = inter2, [1] = inter3, [2] = end }
+                Outputs = { [0] = inter2, [1] = inter3, [2] = end },
+                Position = new Point(3, 4),
             };
 
             var unmount1 = new TaskA
             {
                 Inputs = {[0] = inter2},
-                Outputs = {[0] = end, [1] = end, [2] = end }
+                Outputs = {[0] = end, [1] = end, [2] = end },
+                Position = new Point(5, 6),
             };
 
             var unmount2 = new TaskB
             {
                 Inputs = { [0] = inter3 },
-                Outputs = { [0] = end, [1] = end, [2] = end }
+                Outputs = { [0] = end, [1] = end, [2] = end },
+                Position = new Point(7, 8),
             };
 
             workplan.Add(mount, identity, unmount1, unmount2);

--- a/src/Tests/Moryx.Products.IntegrationTests/RecipeStorage/RecipeStorageTests.cs
+++ b/src/Tests/Moryx.Products.IntegrationTests/RecipeStorage/RecipeStorageTests.cs
@@ -100,11 +100,11 @@ namespace Moryx.Products.IntegrationTests
                 State = WorkplanState.Released
             };
 
-            var start = Workflow.CreateConnector("Start", NodeClassification.Start);
-            var end = Workflow.CreateConnector("End", NodeClassification.End);
-            var inter1 = Workflow.CreateConnector("Inter1");
-            var inter2 = Workflow.CreateConnector("Inter2");
-            var inter3 = Workflow.CreateConnector("Inter3");
+            var start = WorkplanInstance.CreateConnector("Start", NodeClassification.Start);
+            var end = WorkplanInstance.CreateConnector("End", NodeClassification.End);
+            var inter1 = WorkplanInstance.CreateConnector("Inter1");
+            var inter2 = WorkplanInstance.CreateConnector("Inter2");
+            var inter3 = WorkplanInstance.CreateConnector("Inter3");
             workplan.Add(start, end, inter1, inter2, inter3);
 
             var mount = new TaskA


### PR DESCRIPTION
Therfore the existing migration has been updated instead of creating a new one. Assuming, new migrations won't be needed before release.

