### PR TITLE
Fix Resources

### DIFF
--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceQueryConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceQueryConverter.cs
@@ -47,7 +47,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         private ResourceReferenceModel[] FilteredReferences(Resource current)
         {
             // Get references of the instance and filter them
-            var node = TypeController[current.GetType().Name];     
+            var node = TypeController[current.GetType().FullName];     
             var references = node.References;
     
 

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
@@ -107,7 +107,8 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         /// </summary>
         private ResourceReferenceModel[] ConvertReferences(Resource current)
         {
-            var node = TypeController[current.GetType().Name];
+            var name = current.GetType().FullName;
+            var node = TypeController[name];
        
             // Find all reference properties on the object
             var referenceProperties = node.References;

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/Converter/ResourceToModelConverter.cs
@@ -55,6 +55,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         /// <returns></returns>
         public ResourceModel GetDetails(Resource current)
         {
+            if (current == null) return null;
             return ToModel(current, false);
         }
 
@@ -66,6 +67,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         /// <returns></returns>
         protected ResourceModel ToModel(Resource current, bool partially)
         {
+            if (current == null) return null;
             // Extract model
             var model = new ResourceModel
             {

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -83,10 +83,6 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
         [Authorize(Policy = ResourcePermissions.CanViewDetails)]
         public ActionResult<ResourceModel> GetDetails(long id)
         {
-            var resources = _resourceManagement.GetAllResources<IResource>(r => r.Id == id).ToList();
-            if (resources is null || resources.Count == 0)
-                return NotFound($"Resource '{id}' not found!");
-
             var converter = new ResourceToModelConverter(_resourceTypeTree, _serialization);
             var resourceModel = _resourceManagement.Read(id, r => converter.GetDetails(r));
             if (resourceModel is null)

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -71,7 +71,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
             var resourceProxies = _resourceManagement.GetAllResources<IResource>(r => filter.Match(r as Resource)).ToArray();
 
             var converter = new ResourceQueryConverter(_resourceTypeTree, _serialization, query);
-            var values = resourceProxies.Select(p => _resourceManagement.Read(p.Id, r => converter.QueryConversion(r))).ToArray();
+            var values = resourceProxies.Select(p => _resourceManagement.Read(p.Id, r => converter.QueryConversion(r))).Where(details => details != null).ToArray();
             return values;
         }
 

--- a/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
+++ b/src/Moryx.AbstractionLayer.Resources.Endpoints/ResourceManagementController.cs
@@ -351,7 +351,7 @@ namespace Moryx.AbstractionLayer.Resources.Endpoints
                 if (_query.ReferenceCondition == null)
                     return true;
 
-                var node = _resourceTypeTree[instance.GetType().Name];
+                var node = _resourceTypeTree[instance.GetType().FullName];
 
                 var referenceCondition = _query.ReferenceCondition;
                 var references = (from property in node.PropertiesOfResourceType

--- a/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
@@ -131,8 +131,6 @@ namespace Moryx.Resources.Management
             ValidateHealthState();
 
             var resource = ResourceGraph.Get(id);
-            if (resource == null)
-                throw new KeyNotFoundException($"No resource with Id {id} found!");
 
             var result = accessor(resource);
             return result;

--- a/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceManagementFacade.cs
@@ -126,6 +126,13 @@ namespace Moryx.Resources.Management
             return resource.Id;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="id"></param>
+        /// <param name="accessor"></param>
+        /// <returns>null, when a resource with this id doesn't exist</returns>
         public TResult Read<TResult>(long id, Func<Resource, TResult> accessor)
         {
             ValidateHealthState();

--- a/src/Moryx.Resources.Management/Facades/ResourceTypeTreeFacade.cs
+++ b/src/Moryx.Resources.Management/Facades/ResourceTypeTreeFacade.cs
@@ -1,10 +1,11 @@
 ﻿using Moryx.AbstractionLayer.Resources;
+using Moryx.Runtime.Modules;
 using System;
 using System.Collections.Generic;
 
 namespace Moryx.Resources.Management.Facades
 {
-    internal class ResourceTypeTreeFacade: IResourceTypeTree
+    internal class ResourceTypeTreeFacade: IResourceTypeTree, IFacadeControl
     {
         #region Dependency Injection
 
@@ -12,6 +13,8 @@ namespace Moryx.Resources.Management.Facades
         #endregion
         #region IResourceTypeTree
         public IResourceTypeNode RootType => TypeTree.RootType;
+
+        public Action ValidateHealthState { get; set; }
 
         public IResourceTypeNode this[string typeName] => TypeTree[typeName];
 
@@ -23,6 +26,16 @@ namespace Moryx.Resources.Management.Facades
         public IEnumerable<IResourceTypeNode> SupportedTypes(ICollection<Type> constraints)
         {
             return TypeTree.SupportedTypes(constraints);
+        }
+
+        public void Activate()
+        {
+            
+        }
+
+        public void Deactivate()
+        {
+
         }
 
 

--- a/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
+++ b/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
@@ -80,8 +80,10 @@ namespace Moryx.Resources.Management
             resourceManager.Start();
 
             // Activate external facade to register events
+            ActivateFacade(_resourceTypeTreeFacade);
             ActivateFacade(_notificationSourceFacade);
             ActivateFacade(_resourceManagementFacade);
+  
         }
 
         /// <summary>
@@ -92,7 +94,7 @@ namespace Moryx.Resources.Management
             // Tear down facades
             DeactivateFacade(_notificationSourceFacade);
             DeactivateFacade(_resourceManagementFacade);
-
+            DeactivateFacade(_resourceTypeTreeFacade);
             var resourceManager = Container.Resolve<IResourceManager>();
             resourceManager.Stop();
         }

--- a/src/Moryx.Resources.Management/Resources/IResourceLinker.cs
+++ b/src/Moryx.Resources.Management/Resources/IResourceLinker.cs
@@ -33,7 +33,7 @@ namespace Moryx.Resources.Management
         /// in relations on the fly.
         /// </summary>
         /// <returns>Found new instances</returns>
-        IReadOnlyList<Resource> SaveReferences(IUnitOfWork uow, Resource instance, ResourceEntity entity);
+        IReadOnlyList<Resource> SaveReferences(IUnitOfWork uow, Resource instance, ResourceEntity entity, Dictionary<Resource, ResourceEntity> partsDict = null);
 
         /// <summary>
         /// Save changes to a single collection

--- a/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceLinker.cs
@@ -85,16 +85,18 @@ namespace Moryx.Resources.Management
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<Resource> SaveReferences(IUnitOfWork uow, Resource instance, ResourceEntity entity)
+        public IReadOnlyList<Resource> SaveReferences(IUnitOfWork uow, Resource instance, ResourceEntity entity, Dictionary<Resource, ResourceEntity> dict = null)
         {
             var context = new ReferenceSaverContext(uow, Graph, instance, entity);
-            SaveReferences(context, instance);
+            SaveReferences(context, instance, dict);
             return context.EntityCache.Keys.Where(i => i.Id == 0).ToList();
         }
 
-        private void SaveReferences(ReferenceSaverContext context, Resource instance)
+        private void SaveReferences(ReferenceSaverContext context, Resource instance, Dictionary<Resource, ResourceEntity> dict = null)
         {
             var entity = GetOrCreateEntity(context, instance);
+            if(dict != null)
+                dict.Add(instance, entity);
 
             var relations = ResourceRelationAccessor.FromEntity(context.UnitOfWork, entity)
                 .Union(ResourceRelationAccessor.FromQueryable(context.CreatedRelations.AsQueryable(), entity))
@@ -122,7 +124,7 @@ namespace Moryx.Resources.Management
 
             // Recursively save references for new resources
             foreach (var resource in createdResources)
-                SaveReferences(context, resource);
+                SaveReferences(context, resource, dict);
         }
 
         /// <inheritdoc />

--- a/src/Moryx.Resources.Management/Resources/ResourceManager.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceManager.cs
@@ -292,13 +292,21 @@ namespace Moryx.Resources.Management
                 if (saveResult.Item2)
                     newResources.Add(resource);
 
-                var newInstances = ResourceLinker.SaveReferences(uow, resource, entity);
+                var references = new Dictionary<Resource, ResourceEntity>();
+                var newInstances = ResourceLinker.SaveReferences(uow, resource, entity, references);
                 newResources.AddRange(newInstances);
 
                 try
                 {
                     uow.SaveChanges();
                     resource.Id = entity.Id;
+                    foreach(var instance in newResources)
+                    {
+                        if (!references.ContainsKey(instance))
+                            continue;
+                        instance.Id = references[instance].Id;
+                    }
+
                 }
                 catch (Exception ex)
                 {

--- a/src/Moryx.Resources.Samples/AssembleResource.cs
+++ b/src/Moryx.Resources.Samples/AssembleResource.cs
@@ -28,8 +28,7 @@ namespace Moryx.Resources.Samples
 
             if (Setup == null)
             {
-                Setup = Graph.Instantiate<AssembleFoo>();
-                Graph.Save(Setup);
+                Setup = Graph.Instantiate<AssembleFoo>();              
                 RaiseResourceChanged();
             }
         }

--- a/src/Moryx.Resources.Samples/AssembleResource.cs
+++ b/src/Moryx.Resources.Samples/AssembleResource.cs
@@ -29,6 +29,7 @@ namespace Moryx.Resources.Samples
             if (Setup == null)
             {
                 Setup = Graph.Instantiate<AssembleFoo>();
+                Graph.Save(Setup);
                 RaiseResourceChanged();
             }
         }

--- a/src/Tests/Moryx.Resources.Management.Tests/ResourceManagerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/ResourceManagerTests.cs
@@ -43,14 +43,16 @@ namespace Moryx.Resources.Management.Tests
             _typeControllerMock = new Mock<IResourceTypeController>();
 
             _linkerMock = new Mock<IResourceLinker>();
-            _linkerMock.Setup(l => l.SaveReferences(It.IsAny<IUnitOfWork>(), It.IsAny<Resource>(), It.IsAny<ResourceEntity>()))
+            _linkerMock.Setup(l => l.SaveReferences(It.IsAny<IUnitOfWork>(), It.IsAny<Resource>(), It.IsAny<ResourceEntity>(), 
+                It.IsAny<Dictionary<Resource,ResourceEntity>>()))
                 .Returns(new Resource[0]);
 
             _initializerMock = new Mock<IResourceInitializer>();
             _initializerMock.Setup(i => i.Execute(It.IsAny<IResourceGraph>())).Returns(new[] { _resourceMock });
             _linkerMock.Setup(l => l.SaveRoots(It.IsAny<IUnitOfWork>(), It.IsAny<IReadOnlyList<Resource>>()))
                 .Returns(new[] { _resourceMock });
-            _linkerMock.Setup(l => l.SaveReferences(It.IsAny<IUnitOfWork>(), It.IsAny<Resource>(), It.IsAny<ResourceEntity>()))
+            _linkerMock.Setup(l => l.SaveReferences(It.IsAny<IUnitOfWork>(), It.IsAny<Resource>(), It.IsAny<ResourceEntity>(),
+                It.IsAny<Dictionary<Resource, ResourceEntity>>()))
                 .Returns(new Resource[0]);
 
             _graph = new ResourceGraph { TypeController = _typeControllerMock.Object };
@@ -168,7 +170,8 @@ namespace Moryx.Resources.Management.Tests
             _resourceManager.Save(_resourceMock);
 
             // Assert
-            _linkerMock.Verify(l => l.SaveReferences(It.IsAny<IUnitOfWork>(), _resourceMock, It.IsAny<ResourceEntity>()), Times.Once);
+            _linkerMock.Verify(l => l.SaveReferences(It.IsAny<IUnitOfWork>(), _resourceMock, It.IsAny<ResourceEntity>(),
+                It.IsAny<Dictionary<Resource, ResourceEntity>>()), Times.Once);
 
             using (var uow = _modelFactory.Create())
             {
@@ -195,7 +198,8 @@ namespace Moryx.Resources.Management.Tests
             testResource.RaiseChanged();
 
             // Assert
-            _linkerMock.Verify(l => l.SaveReferences(It.IsAny<IUnitOfWork>(), testResource, It.IsAny<ResourceEntity>()), Times.Once);
+            _linkerMock.Verify(l => l.SaveReferences(It.IsAny<IUnitOfWork>(), testResource, It.IsAny<ResourceEntity>()
+                , It.IsAny<Dictionary<Resource, ResourceEntity>>()), Times.Once);
 
             ResourceEntity entity;
             using (var uow = _modelFactory.Create())


### PR DESCRIPTION
- Fix using Fullname to organizie resource types
- Fix registering the ResourceTypeTreeFacade
- Fix invoking methods of resources with void as return value
- Trying to access a resource that doesn't exists stops throwing an exception
- When the AssemblyResource creates an AssemblyFoo resource during the creation, the id will be updated