### PR TITLE
Prevent Notification from throwing InvalidOperationException in the event of a race condition in the NotificationAdapter

### DIFF
--- a/src/Moryx.Notifications/NotificationExtensions.cs
+++ b/src/Moryx.Notifications/NotificationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Moryx.Container;
+using Moryx.Logging;
 
 namespace Moryx.Notifications
 {
@@ -12,7 +13,9 @@ namespace Moryx.Notifications
         /// </summary>
         public static IContainer RegisterNotifications(this IContainer container)
         {
-            var adapter = new NotificationAdapter();
+            var logger = container.Resolve<IModuleLogger>();
+
+            var adapter = new NotificationAdapter { Logger = logger };
 
             container.SetInstance((INotificationAdapter)adapter, "NotificationAdapter");
             container.SetInstance((INotificationSourceAdapter)adapter, "NotificationSenderAdapter");


### PR DESCRIPTION
### Summary

The standard implementation of `INotification` throws an `InvalidOperationException` when a Notification is acknowledged a second time. The `NotificationAdapter` has a fallback behaviour if a notification should be processed but cannot be found in the pending publications. The method acknowledges the `Notification` without checking whether it is already acknowledged.

This PR adds a check for this circumstance and logs information on who and when the Notification was acknowledged.