### PR TITLE
Add missing union on lists in NotificationAdapter

### DIFF
--- a/src/Moryx.Notifications/Adapter/NotificationAdapter.cs
+++ b/src/Moryx.Notifications/Adapter/NotificationAdapter.cs
@@ -15,11 +15,11 @@ namespace Moryx.Notifications
     /// </summary>
     public class NotificationAdapter : INotificationAdapter, INotificationSourceAdapter
     {
-        private readonly List<NotificationMap> _published = new List<NotificationMap>();
-        private readonly List<NotificationMap> _pendingAcks = new List<NotificationMap>();
-        private readonly List<NotificationMap> _pendingPubs = new List<NotificationMap>();
+        private readonly List<NotificationMap> _published = new List<NotificationMap>(16);
+        private readonly List<NotificationMap> _pendingAcks = new List<NotificationMap>(16);
+        private readonly List<NotificationMap> _pendingPubs = new List<NotificationMap>(16);
 
-        private readonly ReaderWriterLockSlim _listLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+        private readonly object _listLock = new ();
 
         /// <summary>
         /// Logger for the Notification Adapter
@@ -42,13 +42,13 @@ namespace Moryx.Notifications
 
         private IReadOnlyList<INotification> GetPublished(Func<NotificationMap, bool> filter)
         {
-            _listLock.EnterReadLock();
-
-            var notifications = _published.Union(_pendingPubs).Where(filter)
+            IReadOnlyList<INotification> notifications;
+            lock (_listLock)
+            {
+                notifications = _published.Union(_pendingPubs).Where(filter)
                 .Select(map => map.Notification)
                 .ToArray();
-
-            _listLock.ExitReadLock();
+            }
 
             return notifications;
         }
@@ -68,29 +68,23 @@ namespace Moryx.Notifications
             if (notification == null)
                 throw new ArgumentNullException(nameof(notification), "Notification must be set");
 
-            _listLock.EnterUpgradeableReadLock();
-
-            // Lets check if the notification was already published
-            var isPending = _pendingPubs.Union(_pendingAcks).Union(_published)
-                .Any(n => n.Notification == notification);
-
-            if (isPending)
+            
+            lock (_listLock)
             {
-                _listLock.ExitUpgradeableReadLock();
-                throw new InvalidOperationException("Notification cannot be published twice!");
+                // Lets check if the notification was already published
+                var isPending = _pendingPubs.Union(_pendingAcks).Union(_published)
+                    .Any(n => n.Notification == notification);
+
+                if (isPending)
+                    throw new InvalidOperationException("Notification cannot be published twice!");
+
+                var managed = (IManagedNotification)notification;
+                managed.Identifier = Guid.NewGuid();
+                managed.Created = DateTime.Now;
+                managed.Sender = sender.Identifier;
+
+                _pendingPubs.Add(new NotificationMap(sender, notification, tag));
             }
-
-            _listLock.EnterWriteLock();
-
-            var managed = (IManagedNotification)notification;
-            managed.Identifier = Guid.NewGuid();
-            managed.Created = DateTime.Now;
-            managed.Sender = sender.Identifier;
-
-            _pendingPubs.Add(new NotificationMap(sender, notification, tag));
-
-            _listLock.ExitWriteLock();
-            _listLock.ExitUpgradeableReadLock();
 
             Published?.Invoke(this, notification);
         }
@@ -108,32 +102,28 @@ namespace Moryx.Notifications
             managed.Acknowledged = DateTime.Now;
             managed.Acknowledger = sender.Identifier;
 
-            _listLock.EnterWriteLock();
-
-            var published = _published.SingleOrDefault(n => n.Notification.Identifier == notification.Identifier);
-            if (published != null)
+            NotificationMap published;
+            lock (_listLock)
             {
-                _published.Remove(published);
-            }
-            else
-            {
-                published = _pendingPubs.SingleOrDefault(n => n.Notification.Identifier == notification.Identifier);
-
-                if (published == null)
+                published = _published.SingleOrDefault(n => n.Notification.Identifier == notification.Identifier);
+                if (published is not null)
+                    _published.Remove(published);
+                else
                 {
-                    _listLock.ExitWriteLock();
-                    throw new InvalidOperationException("Notification was not managed by the adapter. " +
-                                                        "The sender was not registered on the adapter");
+                    published = _pendingPubs.SingleOrDefault(n => n.Notification.Identifier == notification.Identifier);
+
+                    if (published is null)
+                        throw new InvalidOperationException("Notification was not managed by the adapter. " +
+                                                            "The sender was not registered on the adapter");
+
+                    _pendingPubs.Remove(published);
                 }
 
-                _pendingPubs.Remove(published);
+                _pendingAcks.Add(published);
             }
 
-            _pendingAcks.Add(published);
-
-            _listLock.ExitWriteLock();
-
-            Acknowledged?.Invoke(this, published.Notification);
+            if (published is not null)
+                Acknowledged?.Invoke(this, published.Notification);
         }
 
         /// <inheritdoc />
@@ -153,24 +143,24 @@ namespace Moryx.Notifications
         /// </summary>
         private void AcknowledgeByFilter(INotificationSender sender, Predicate<NotificationMap> filter)
         {
-            _listLock.EnterWriteLock();
-
-            var publishes = _published.Where(m => filter(m)).ToArray();
-            _published.RemoveAll(filter);
-            _pendingPubs.RemoveAll(filter);
-
-            foreach (var published in publishes)
+            NotificationMap[] publishes;
+            lock (_listLock)
             {
-                var managed = (IManagedNotification)published.Notification;
-                managed.Acknowledged = DateTime.Now;
-                managed.Acknowledger = sender.Identifier;
+                publishes = _published.Union(_pendingPubs).Where(m => filter(m)).ToArray();
+                _published.RemoveAll(filter);
+                _pendingPubs.RemoveAll(filter);
 
-                _pendingAcks.Add(published);
+                foreach (var published in publishes)
+                {
+                    var managed = (IManagedNotification)published.Notification;
+                    managed.Acknowledged = DateTime.Now;
+                    managed.Acknowledger = sender.Identifier;
+
+                    _pendingAcks.Add(published);
+                }
             }
 
-            _listLock.ExitWriteLock();
-
-            foreach (var published in publishes)
+            foreach (var published in publishes ?? new NotificationMap[0]) // ToDo: Change to Array.Empty in MROYX 6
                 Acknowledged?.Invoke(this, published.Notification);
         }
 
@@ -181,11 +171,11 @@ namespace Moryx.Notifications
         /// <inheritdoc />
         IReadOnlyList<INotification> INotificationSourceAdapter.GetPublished()
         {
-            _listLock.EnterReadLock();
-
-            var published = _published.Union(_pendingAcks).Select(map => map.Notification).ToArray();
-
-            _listLock.ExitReadLock();
+            IReadOnlyList<INotification> published;
+            lock (_listLock)
+            {
+                published = _published.Union(_pendingAcks).Select(map => map.Notification).ToArray();
+            }
 
             return published;
         }
@@ -193,80 +183,81 @@ namespace Moryx.Notifications
         /// <inheritdoc />
         void INotificationSourceAdapter.Acknowledge(INotification notification)
         {
-            _listLock.EnterReadLock();
-
-            var map = _published.Single(m => m.Notification.Identifier == notification.Identifier);
-
-            _listLock.ExitReadLock();
-
-            map.Sender.Acknowledge(map.Notification, map.Tag);
+            NotificationMap map;
+            lock (_listLock)
+            {
+                map = _published.Single(m => m.Notification.Identifier == notification.Identifier);
+            }
+            
+            map?.Sender.Acknowledge(map.Notification, map.Tag);
         }
 
         /// <inheritdoc />
         void INotificationSourceAdapter.AcknowledgeProcessed(INotification notification)
         {
-            _listLock.EnterWriteLock();
+            lock (_listLock)
+            {
+                var map = _pendingAcks.SingleOrDefault(n => n.Notification.Identifier.Equals(notification.Identifier));
 
-            var map = _pendingAcks.SingleOrDefault(n => n.Notification.Identifier.Equals(notification.Identifier));
-
-            // Maybe already removed from this adapter
-            if (map != null)
-                _pendingAcks.Remove(map);
-
-            _listLock.ExitWriteLock();
+                // Maybe already removed from this adapter
+                if (map is not null)
+                    _pendingAcks.Remove(map);
+            }
         }
 
         /// <inheritdoc />
         void INotificationSourceAdapter.PublishProcessed(INotification notification)
         {
-            _listLock.EnterWriteLock();
-
-            var map = _pendingPubs.SingleOrDefault(n => n.Notification.Identifier.Equals(notification.Identifier));
-
-            if (map != null)
+            NotificationMap map;
+            lock (_listLock)
             {
-                _pendingPubs.Remove(map);
-                _published.Add(map);
-                _listLock.ExitWriteLock();
-                return;
-            }
+                map = _pendingPubs.SingleOrDefault(n => n.Notification.Identifier.Equals(notification.Identifier));
 
-            // Notification is maybe not pending anymore
-            _listLock.ExitWriteLock();
+                if (map != null)
+                {
+                    _pendingPubs.Remove(map);
+                    _published.Add(map);
+                    return;
+                }
+            }
+            
             var managed = (IManagedNotification)notification;
 
             // If necessary we can acknowledge it
             if (managed.Acknowledged is null)
             {
-                Logger.Log(LogLevel.Error, "Notification was removed from the pending publications " +
-                    "before being published but is not acknowledged.");
+                Logger.Log(LogLevel.Error, "Notification {0} was removed from the pending publications " +
+                    "before being published but is not acknowledged.", managed.Identifier);
                 managed.Acknowledged = DateTime.Now;
                 managed.Acknowledger = nameof(NotificationAdapter);
                 Acknowledged?.Invoke(this, notification);
             }
 
-            Logger.Log(LogLevel.Warning, "Notification was removed from the pending publications. " +
-                "It was already acknowledged by {0} at {1}.", managed.Acknowledger, managed.Acknowledged);
+            Logger.Log(LogLevel.Warning, "Notification {0} was removed from the pending publications. " +
+                "It was already acknowledged by {1} at {2}.", managed.Identifier, managed.Acknowledger, managed.Acknowledged);
         }
 
         /// <inheritdoc />
         void INotificationSourceAdapter.Sync()
         {
             // Publish pending notifications
-            _listLock.EnterReadLock();
-            var pendingPublishs = _pendingPubs.ToArray();
-            _listLock.ExitReadLock();
-
-            foreach (var pendingPublish in pendingPublishs)
+            NotificationMap[] pendingPublishes = new NotificationMap[0]; // ToDo: Replace with Array.Empty in MORYX 6
+            lock (_listLock)
+            {
+                pendingPublishes = _pendingPubs.ToArray();
+            }
+            foreach (var pendingPublish in pendingPublishes)
             {
                 Published?.Invoke(this, pendingPublish.Notification);
             }
 
             // Acknowledge pending acknowledges
-            _listLock.EnterReadLock();
-            var pendingAcks = _pendingAcks.ToArray();
-            _listLock.ExitReadLock();
+            NotificationMap[] pendingAcks = new NotificationMap[0]; // ToDo: Replace with Array.Empty in MORYX 6
+            lock (_listLock)
+            {
+                pendingAcks = _pendingAcks.ToArray();
 
+            }
             foreach (var pendingAck in pendingAcks)
             {
                 Acknowledged?.Invoke(this, pendingAck.Notification);

--- a/src/Tests/Moryx.Notifications.Tests/NotificationAdapterTests.cs
+++ b/src/Tests/Moryx.Notifications.Tests/NotificationAdapterTests.cs
@@ -49,7 +49,7 @@ namespace Moryx.Notifications.Tests
         }
 
         [Test(Description = "Check that publishing a notification publishes an event, and marks the notification as published. " +
-                            "Check, that notifications can not be published twice.")]
+                            "Check that notifications can not be published twice.")]
         public void AdapterPublish()
         {
             // Arrange
@@ -80,9 +80,9 @@ namespace Moryx.Notifications.Tests
             // Act
             _adapter.Publish(_sender, notification, tag);
             ((INotificationSourceAdapter)_adapter).PublishProcessed(notification);
-
-            // Arrange
             var published = _adapter.GetPublished(_sender, tag);
+
+            // Assert
             Assert.AreEqual(1, published.Count);
         }
 
@@ -119,7 +119,7 @@ namespace Moryx.Notifications.Tests
             Assert.AreNotEqual(_acknowledgedEventNotification.Acknowledged, default(DateTime), "Acknowledged date should have been set");
         }
 
-        [Test(Description = "Check that acknowledging a notification by the adapter for a known notification throws an exception.")]
+        [Test(Description = "Check that acknowledging a notification by the adapter for an unknown notification throws an exception.")]
         public void AdapterAcknowledgeForUnknownNotification()
         {
             // Arrange
@@ -150,9 +150,6 @@ namespace Moryx.Notifications.Tests
             Assert.AreEqual(notification, _acknowledgeCallNotification, "Acknowledged was not called for the wrong notification.");
         }
 
-        /// <summary>
-        /// Check that acknowledging a notification by the SenderAdapter-interface for an unknown notification throws an exception.
-        /// </summary>
         [Test(Description = "Check that acknowledging a notification by the SenderAdapter-interface for an unknown notification throws an exception.")]
         public void SenderAdapterAcknowledgeForUnknownNotification()
         {


### PR DESCRIPTION
Because of the missing union in the AcknowledgeByFilter method, notifications got removed from the pendingPublications but not acknowledged. Also the ReaderWriterLock got replaced to increase stability by preventing deadlocks.

Complements #217 by resolving the underlying issue

/cc @dacky179 