### PR TITLE
Adds the AllowMultiple flag to the ResourceAvailableAs attribute

### DIFF
--- a/src/Moryx.AbstractionLayer/Resources/Attributes/ResourceAvailableAsAttribute.cs
+++ b/src/Moryx.AbstractionLayer/Resources/Attributes/ResourceAvailableAsAttribute.cs
@@ -8,7 +8,7 @@ namespace Moryx.AbstractionLayer.Resources
     /// <summary>
     /// Members of the given interfaces are available outside of the resource management
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class ResourceAvailableAsAttribute : Attribute
     {
         /// <summary>

--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/DerivedResourceWithNewProxy.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/DerivedResourceWithNewProxy.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2023, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Resources;
+
+namespace Moryx.Resources.Management.Tests
+{
+    public interface ISecondNonResourceInterface
+    {
+    }
+
+    [ResourceAvailableAs(typeof(ISecondNonResourceInterface))]
+    public class DerivedResourceWithNewProxy : SimpleResource, ISecondNonResourceInterface
+    {
+        public override int MultiplyFoo(int factor)
+        {
+            return Foo *= factor + 2;
+        }
+    }
+}

--- a/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
@@ -28,6 +28,7 @@ namespace Moryx.Resources.Management.Tests
                     typeof(DerivedResource),
                     typeof(ReferenceResource),
                     typeof(NonPublicResource),
+                    typeof(DerivedResourceWithNewProxy),
                     typeof(ResourceWithImplicitApi)
                 });
 
@@ -77,6 +78,21 @@ namespace Moryx.Resources.Management.Tests
 
             // Assert: Make sure proxy is still the base type
             Assert.AreEqual(baseProxy.GetType(), proxy.GetType());
+        }
+
+        [Test]
+        public void UseNewProxyForDerivedTypeWithNewInterface()
+        {
+            // Arrange: Create instance
+            var baseInstance = new SimpleResource { Id = 2 };
+            var instance = new DerivedResourceWithNewProxy { Id = 3 };
+
+            // Act: Build Proxy
+            var baseProxy = _typeController.GetProxy(baseInstance);
+            var proxy = _typeController.GetProxy(instance);
+
+            // Assert: Make sure proxy is still the base type
+            Assert.That(baseProxy.GetType(), Is.Not.EqualTo(proxy.GetType()));
         }
 
         [Test]


### PR DESCRIPTION
When searching for the relevant interfaces to build the resource proxies in the ResourceTypeController, the method creates a list of distinct instanzes of the attribute. However, without the AllowMultiple flag on the attribute this call will never return more than one element. Therefore, the missing flag is added.

