### PR TITLE
Fix NullReference exceptions in ResourceProxy

### DIFF
--- a/src/Moryx.Resources.Management/Resources/ResourceProxy.cs
+++ b/src/Moryx.Resources.Management/Resources/ResourceProxy.cs
@@ -58,6 +58,8 @@ namespace Moryx.Resources.Management
         protected internal TResource Convert<TResource>(IResource instance)
             where TResource : IResource
         {
+            if (instance is null) return default;
+
             return (TResource)_typeController.GetProxy((Resource)instance);
         }
 
@@ -67,6 +69,8 @@ namespace Moryx.Resources.Management
         protected internal TResource[] ConvertMany<TResource>(IEnumerable<IResource> instances)
             where TResource : IResource
         {
+            if (instances is null) return default;
+
             return instances.Select(Convert<TResource>).ToArray();
         }
 
@@ -76,6 +80,8 @@ namespace Moryx.Resources.Management
         protected internal static TResource Extract<TResource>(IResource instance)
             where TResource : IResource
         {
+            if (instance is null) return default;
+
             var proxy = (ResourceProxy)instance;
             return (TResource)proxy.Target;
         }
@@ -86,6 +92,8 @@ namespace Moryx.Resources.Management
         protected internal static TResource[] ExtractMany<TResource>(IEnumerable<IResource> instances)
             where TResource : IResource
         {
+            if (instances is null) return default;
+
             return instances.Select(Extract<TResource>).ToArray();
         }
     }

--- a/src/Tests/Moryx.Resources.Management.Tests/Mocks/ReferenceResource.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/Mocks/ReferenceResource.cs
@@ -13,7 +13,11 @@ namespace Moryx.Resources.Management.Tests
     {
         ISimpleResource Reference { get; set; }
 
+        DerivedResource Reference2 { get; set; }
+
         IEnumerable<ISimpleResource> MoreReferences { get; }
+
+        IEnumerable<ISimpleResource> EvenMoreReferences { get; set; }
 
         INonPublicResource NonPublic { get; }
 
@@ -71,6 +75,8 @@ namespace Moryx.Resources.Management.Tests
         internal IReferences<ISimpleResource> ChildReferences { get; set; }
 
         IEnumerable<ISimpleResource> IReferenceResource.MoreReferences => References;
+
+        public IEnumerable<ISimpleResource> EvenMoreReferences { get; set; }
 
         public ISimpleResource GetReference()
         {

--- a/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
+++ b/src/Tests/Moryx.Resources.Management.Tests/TypeControllerTests.cs
@@ -220,6 +220,8 @@ namespace Moryx.Resources.Management.Tests
             {
                 Id = 8,
                 Reference = ref1,
+                Reference2 = null,
+                EvenMoreReferences = null,
                 NonPublic = nonPub
             };
             instance.References = new ReferenceCollection<ISimpleResource>(instance,
@@ -265,6 +267,11 @@ namespace Moryx.Resources.Management.Tests
             Assert.AreEqual(instance.Reference, ref2);
             Assert.AreEqual(instance.References.Count, 3);
             Assert.AreEqual(instance.References.ElementAt(1), ref1);
+            // Make sure null references work
+            Assert.DoesNotThrow(() => _ = proxy.Reference2);
+            Assert.DoesNotThrow(() => proxy.Reference2 = null);
+            Assert.DoesNotThrow(() => _ = proxy.EvenMoreReferences);
+            Assert.DoesNotThrow(() => proxy.EvenMoreReferences = null);
         }
 
     }


### PR DESCRIPTION
When setting or getting  the value of a reference property of a resource proxy no null checks where executed. By adding the null checks we prevent exceptions to be thrown when using getters and setters on proxies.

