### PR TITLE
Fix problem while publishing notifications during OnStart

### DIFF
--- a/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
+++ b/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
@@ -95,6 +95,8 @@ namespace Moryx.Resources.Management
         /// </summary>
         protected override void OnStart()
         {
+            ActivateFacade(_notificationSourceFacade);
+
             // Start type controller for resource and proxy creation
             Container.Resolve<IResourceTypeController>().Start();
 
@@ -106,7 +108,6 @@ namespace Moryx.Resources.Management
             resourceManager.Start();
 
             // Activate external facade to register events
-            ActivateFacade(_notificationSourceFacade);
             ActivateFacade(_resourceManagementFacade);
         }
 
@@ -116,11 +117,12 @@ namespace Moryx.Resources.Management
         protected override void OnStop()
         {
             // Tear down facades
-            DeactivateFacade(_notificationSourceFacade);
             DeactivateFacade(_resourceManagementFacade);
 
             var resourceManager = Container.Resolve<IResourceManager>();
             resourceManager.Stop();
+
+            DeactivateFacade(_notificationSourceFacade);
         }
 
         private readonly ResourceManagementFacade _resourceManagementFacade = new ResourceManagementFacade();


### PR DESCRIPTION
Change order of activation of the notification facade. Facade must be ready before resources are starting, to allow publish notification during OnStart().