### PR TITLE
Skip ValidateHealthState if NotificationSourceFacade is activated

### DIFF
--- a/src/Moryx.Notifications/Facade/NotificationSourceFacade.cs
+++ b/src/Moryx.Notifications/Facade/NotificationSourceFacade.cs
@@ -35,14 +35,15 @@ namespace Moryx.Notifications
         /// </summary>
         public INotificationSourceAdapter NotificationAdapter { get; set; }
 
+
         /// <inheritdoc />
         public override void Activate()
         {
             base.Activate();
-
+            
             NotificationAdapter.Published += OnNotificationPublished;
             NotificationAdapter.Acknowledged += OnNotificationAcknowledged;
-        }
+       }
 
         /// <inheritdoc />
         public override void Deactivate()
@@ -56,35 +57,40 @@ namespace Moryx.Notifications
         /// <inheritdoc />
         public IReadOnlyList<INotification> GetPublished()
         {
-            ValidateHealthState();
+            if (!IsActivated)
+                ValidateHealthState();
             return NotificationAdapter.GetPublished();
         }
 
         /// <inheritdoc />
         public void Sync()
         {
-            ValidateHealthState();
+            if (!IsActivated)
+                ValidateHealthState();
             NotificationAdapter.Sync();
         }
 
         /// <inheritdoc />
         public void Acknowledge(INotification notification)
         {
-            ValidateHealthState();
+            if (!IsActivated)
+                ValidateHealthState();
             NotificationAdapter.Acknowledge(notification);
         }
 
         /// <inheritdoc />
         public void PublishProcessed(INotification notification)
         {
-            ValidateHealthState();
+            if (!IsActivated)
+                ValidateHealthState();
             NotificationAdapter.PublishProcessed(notification);
         }
 
         /// <inheritdoc />
         public void AcknowledgeProcessed(INotification notification)
         {
-            ValidateHealthState();
+            if (!IsActivated)
+                ValidateHealthState();
             NotificationAdapter.AcknowledgeProcessed(notification);
         }
 


### PR DESCRIPTION
A resource is allowed to publish notifications during startup. But if it does he could get a Notification that is not acknowledgeable.
The NotificationSourceFacade allows to publish a notification but does not allow to receive a NotificationPublished-callback until the underlying Module is started completely.
This change limits the health state validation to the time the NotificationSourceFacade was is not activiated.