### PR TITLE
Feature/revert notification source facade changes

### DIFF
--- a/src/Moryx.Notifications/Facade/NotificationSourceFacade.cs
+++ b/src/Moryx.Notifications/Facade/NotificationSourceFacade.cs
@@ -36,9 +36,9 @@ namespace Moryx.Notifications
         public INotificationSourceAdapter NotificationAdapter { get; set; }
 
         /// <inheritdoc />
-        public override void Activate()
+        public override void Activated()
         {
-            base.Activate();
+            base.Activated();
 
             NotificationAdapter.Published += OnNotificationPublished;
             NotificationAdapter.Acknowledged += OnNotificationAcknowledged;

--- a/src/Moryx.Notifications/Facade/NotificationSourceFacade.cs
+++ b/src/Moryx.Notifications/Facade/NotificationSourceFacade.cs
@@ -57,35 +57,40 @@ namespace Moryx.Notifications
         /// <inheritdoc />
         public IReadOnlyList<INotification> GetPublished()
         {
-            ValidateHealthState();
+            if (!IsActivated)
+                ValidateHealthState();
             return NotificationAdapter.GetPublished();
         }
 
         /// <inheritdoc />
         public void Sync()
         {
-            ValidateHealthState();
+            if (!IsActivated)
+                ValidateHealthState();
             NotificationAdapter.Sync();
         }
 
         /// <inheritdoc />
         public void Acknowledge(INotification notification)
         {
-            // No ValidateHealthState: Source published the notification; it must be able to handle a response, too!
+            if (!IsActivated)
+                ValidateHealthState();
             NotificationAdapter.Acknowledge(notification);
         }
 
         /// <inheritdoc />
         public void PublishProcessed(INotification notification)
         {
-            // No ValidateHealthState: Source published the notification; it must be able to handle a response, too!
+            if (!IsActivated)
+                ValidateHealthState();
             NotificationAdapter.PublishProcessed(notification);
         }
 
         /// <inheritdoc />
         public void AcknowledgeProcessed(INotification notification)
         {
-            // No ValidateHealthState: Source acknowledge the notification; it must be able to handle a response, too!
+            if (!IsActivated)
+                ValidateHealthState();
             NotificationAdapter.AcknowledgeProcessed(notification);
         }
 

--- a/src/Moryx.Notifications/Facade/NotificationSourceFacade.cs
+++ b/src/Moryx.Notifications/Facade/NotificationSourceFacade.cs
@@ -35,15 +35,14 @@ namespace Moryx.Notifications
         /// </summary>
         public INotificationSourceAdapter NotificationAdapter { get; set; }
 
-
         /// <inheritdoc />
         public override void Activate()
         {
             base.Activate();
-            
+
             NotificationAdapter.Published += OnNotificationPublished;
             NotificationAdapter.Acknowledged += OnNotificationAcknowledged;
-       }
+        }
 
         /// <inheritdoc />
         public override void Deactivate()
@@ -57,40 +56,35 @@ namespace Moryx.Notifications
         /// <inheritdoc />
         public IReadOnlyList<INotification> GetPublished()
         {
-            if (!IsActivated)
-                ValidateHealthState();
+            ValidateHealthState();
             return NotificationAdapter.GetPublished();
         }
 
         /// <inheritdoc />
         public void Sync()
         {
-            if (!IsActivated)
-                ValidateHealthState();
+            ValidateHealthState();
             NotificationAdapter.Sync();
         }
 
         /// <inheritdoc />
         public void Acknowledge(INotification notification)
         {
-            if (!IsActivated)
-                ValidateHealthState();
+            ValidateHealthState();
             NotificationAdapter.Acknowledge(notification);
         }
 
         /// <inheritdoc />
         public void PublishProcessed(INotification notification)
         {
-            if (!IsActivated)
-                ValidateHealthState();
+            ValidateHealthState();
             NotificationAdapter.PublishProcessed(notification);
         }
 
         /// <inheritdoc />
         public void AcknowledgeProcessed(INotification notification)
         {
-            if (!IsActivated)
-                ValidateHealthState();
+            ValidateHealthState();
             NotificationAdapter.AcknowledgeProcessed(notification);
         }
 

--- a/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
+++ b/src/Moryx.Resources.Management/ModuleController/ModuleController.cs
@@ -95,8 +95,6 @@ namespace Moryx.Resources.Management
         /// </summary>
         protected override void OnStart()
         {
-            ActivateFacade(_notificationSourceFacade);
-
             // Start type controller for resource and proxy creation
             Container.Resolve<IResourceTypeController>().Start();
 
@@ -108,6 +106,7 @@ namespace Moryx.Resources.Management
             resourceManager.Start();
 
             // Activate external facade to register events
+            ActivateFacade(_notificationSourceFacade);
             ActivateFacade(_resourceManagementFacade);
         }
 
@@ -117,12 +116,11 @@ namespace Moryx.Resources.Management
         protected override void OnStop()
         {
             // Tear down facades
+            DeactivateFacade(_notificationSourceFacade);
             DeactivateFacade(_resourceManagementFacade);
 
             var resourceManager = Container.Resolve<IResourceManager>();
             resourceManager.Stop();
-
-            DeactivateFacade(_notificationSourceFacade);
         }
 
         private readonly ResourceManagementFacade _resourceManagementFacade = new ResourceManagementFacade();


### PR DESCRIPTION
Revert changes of the NotificationSourceFacade and ResourceManagement.
@dbeuchler found the real problem within the NotificationPublisher in CS.