### PR TITLE
Enable delete for unused subproducts

### DIFF
--- a/src/Moryx.Products.Management/Implementation/ProductManager.cs
+++ b/src/Moryx.Products.Management/Implementation/ProductManager.cs
@@ -189,7 +189,7 @@ namespace Moryx.Products.Management
                                    select new
                                    {
                                        entity,
-                                       parentCount = entity.Parents.Active().Count // get number of undeleted Parents
+                                       parentCount = entity.Parents.Count(p => p.Parent.Deleted == null) // get number of undeleted Parents
                                    }).FirstOrDefault();
                 // No match, nothing removed!
                 if (queryResult == null)

--- a/src/Moryx.Products.Management/Implementation/ProductManager.cs
+++ b/src/Moryx.Products.Management/Implementation/ProductManager.cs
@@ -189,7 +189,7 @@ namespace Moryx.Products.Management
                                    select new
                                    {
                                        entity,
-                                       parentCount = entity.Parents.Count
+                                       parentCount = entity.Parents.Active().Count // get number of undeleted Parents
                                    }).FirstOrDefault();
                 // No match, nothing removed!
                 if (queryResult == null)


### PR DESCRIPTION
I had situation that a product could not be deleted. I thougth it was a problem with regex search and identifier but now I think it is a problem with usage of the product. 
A product can be deleted if no other product uses that product.

Filter for undeleted parent products.
If all parents are deleted we can delete the subproduct too.
