### PR TITLE
Filter Parent-Property from ProductInstance.

### DIFF
--- a/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
+++ b/src/Moryx.Products.Management/Facades/ProductManagementFacade.cs
@@ -226,8 +226,8 @@ namespace Moryx.Products.Management
                 .GetInstances<IIdentifiableObject>(i => identity.Equals(i.Identity));
             if (instances.Count > 1)
             {
-                Logger.Log(LogLevel.Error, "ProductManagement contains more than one {0} with the identity {1}.", nameof(ProductInstance), identity);
-                throw new InvalidOperationException();
+                Logger.Log(LogLevel.Error, "ProductManagement contains more than one {0} with identity {1}.", nameof(ProductInstance), identity);
+                throw new InvalidOperationException($"More than one instance found!");
             }
                 
             return (ProductInstance) instances.SingleOrDefault(); ;

--- a/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
+++ b/src/Moryx.Products.Management/Implementation/Storage/ProductStorage.cs
@@ -1022,7 +1022,9 @@ namespace Moryx.Products.Management
             strategy.SaveInstance(productInstance, archived);
 
             // Save its parts if they have a dedicated archive
-            var partsContainer = ReflectionTool.GetReferences<ProductInstance>(productInstance);
+            var partsContainer = ReflectionTool.GetReferences<ProductInstance>(productInstance)
+                .Where(p => p.Key.Name != nameof(ProductInstance.Parent));
+
             foreach (var partGroup in partsContainer)
             {
                 foreach (var part in partGroup)


### PR DESCRIPTION
Fix overflow exception when saving a product instance.
Add proper error message when more than one product instance was found.